### PR TITLE
Qualtrics enhancement: allow survey authors to bypass prompt via query string parameter

### DIFF
--- a/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
@@ -96,29 +96,23 @@ class QualtricsAnalyticsClient @Inject constructor(
         qualtrics.registerViewVisit(eventName)
 
         qualtrics.evaluateProject { results ->
-            val targetResult = results.values.filterNotNull().lastOrNull {
-                !it.surveyUrl.isNullOrEmpty()
-            }
+            val passedResults = results.filterValues { it.passed() }
+
+            if (passedResults.isEmpty()) return@evaluateProject
+            val activity = activityProvider.currentActivity ?: return@evaluateProject
+
+            lastShownTargetingIds = passedResults.keys.toList()
+
+            val targetResult = passedResults.values.filterNotNull().firstOrNull()
             val surveyUrl = targetResult?.surveyUrl.orEmpty()
-            val skipPrompt = targetResult?.surveyUrl?.let {
-                it.toUri().query?.contains("hide_prompt=true")
-            } ?: false
+            val skipPrompt = targetResult?.surveyUrl?.toUri()?.query?.contains("hide_prompt=true") == true
 
-            val passedTargetingIds = results.filterValues {
-                it.passed()
-            }.keys.toList()
-
-            if (passedTargetingIds.isNotEmpty()) {
-                activityProvider.currentActivity?.let { activity ->
-                    lastShownTargetingIds = passedTargetingIds
-                    if (skipPrompt) {
-                        qualtrics.displayTarget(context, surveyUrl)
-                    } else {
-                        qualtrics.display(activity)
-                    }
-                    onSurveyShown?.invoke(results)
-                }
+            if (skipPrompt) {
+                qualtrics.displayTarget(context, surveyUrl)
+            } else {
+                qualtrics.display(activity)
             }
+            onSurveyShown?.invoke(results)
         }
     }
 

--- a/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.govuk.analytics
 
 import android.content.Context
+import androidx.core.net.toUri
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.qualtrics.digital.Qualtrics
 import com.qualtrics.digital.QualtricsPopOverActivity
@@ -95,6 +96,14 @@ class QualtricsAnalyticsClient @Inject constructor(
         qualtrics.registerViewVisit(eventName)
 
         qualtrics.evaluateProject { results ->
+            val targetResult = results.values.filterNotNull().lastOrNull {
+                !it.surveyUrl.isNullOrEmpty()
+            }
+            val surveyUrl = targetResult?.surveyUrl.orEmpty()
+            val skipPrompt = targetResult?.surveyUrl?.let {
+                it.toUri().query?.contains("hide_prompt=true")
+            } ?: false
+
             val passedTargetingIds = results.filterValues {
                 it.passed()
             }.keys.toList()
@@ -102,7 +111,11 @@ class QualtricsAnalyticsClient @Inject constructor(
             if (passedTargetingIds.isNotEmpty()) {
                 activityProvider.currentActivity?.let { activity ->
                     lastShownTargetingIds = passedTargetingIds
-                    qualtrics.display(activity)
+                    if (skipPrompt) {
+                        qualtrics.displayTarget(context, surveyUrl)
+                    } else {
+                        qualtrics.display(activity)
+                    }
                     onSurveyShown?.invoke(results)
                 }
             }

--- a/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
@@ -2,6 +2,8 @@ package uk.gov.govuk.analytics
 
 import android.app.Activity
 import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.qualtrics.digital.IQualtricsProjectEvaluationCallback
 import com.qualtrics.digital.Properties
@@ -11,7 +13,9 @@ import com.qualtrics.digital.QualtricsSurveyActivity
 import com.qualtrics.digital.TargetingResult
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.After
@@ -83,9 +87,11 @@ class QualtricsAnalyticsClientTest {
     fun `Given a survey was shown, when the popover activity is destroyed, then notify the survey closed listener with the targeting ids`() {
         val passedResult = mockk<TargetingResult> {
             every { passed() } returns true
+            every { surveyUrl } returns null
         }
         val failedResult = mockk<TargetingResult> {
             every { passed() } returns false
+            every { surveyUrl } returns null
         }
         val mockResults = mapOf("passed_survey" to passedResult, "failed_survey" to failedResult)
         val evaluationCallbackSlot = slot<IQualtricsProjectEvaluationCallback>()
@@ -113,6 +119,7 @@ class QualtricsAnalyticsClientTest {
     fun `Given a survey was shown, when the survey activity is destroyed, then notify the survey closed listener with the targeting ids`() {
         val passedResult = mockk<TargetingResult> {
             every { passed() } returns true
+            every { surveyUrl } returns null
         }
         val mockResults = mapOf("passed_survey" to passedResult)
         val evaluationCallbackSlot = slot<IQualtricsProjectEvaluationCallback>()
@@ -245,6 +252,7 @@ class QualtricsAnalyticsClientTest {
         val params = mapOf("screen_name" to "Settings")
         val result = mockk<TargetingResult> {
             every { passed() } returns true
+            every { surveyUrl } returns null
         }
         val mockResults = mapOf("survey" to result)
         val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
@@ -266,6 +274,7 @@ class QualtricsAnalyticsClientTest {
         val params = mapOf("screen_name" to "Settings")
         val result = mockk<TargetingResult> {
             every { passed() } returns false
+            every { surveyUrl } returns null
         }
         val mockResults = mapOf("survey" to result)
         val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
@@ -340,6 +349,7 @@ class QualtricsAnalyticsClientTest {
         )
         val result = mockk<TargetingResult> {
             every { passed() } returns true
+            every { surveyUrl } returns null
         }
         val mockResults = mapOf("survey" to result)
         val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
@@ -366,6 +376,7 @@ class QualtricsAnalyticsClientTest {
         )
         val result = mockk<TargetingResult> {
             every { passed() } returns false
+            every { surveyUrl } returns null
         }
         val mockResults = mapOf("survey" to result)
         val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
@@ -378,6 +389,41 @@ class QualtricsAnalyticsClientTest {
 
         verify(exactly = 0) {
             qualtrics.display(context)
+        }
+    }
+
+    @Test
+    fun `Given an event and the survey url contains hide_prompt=true, then display the survey target and skip the prompt`() {
+        mockkStatic(Uri::class)
+        try {
+            val params = mapOf("screen_name" to "Settings")
+            val expectedSurveyUrl = "https://example.qualtrics.com/jfe/form/SV_123?hide_prompt=true"
+            val mockUri = mockk<Uri> {
+                every { query } returns "hide_prompt=true"
+            }
+            every { expectedSurveyUrl.toUri() } returns mockUri
+            val result = mockk<TargetingResult> {
+                every { passed() } returns true
+                every { surveyUrl } returns expectedSurveyUrl
+            }
+            val mockResults = mapOf("survey" to result)
+            val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
+
+            every { activityProvider.currentActivity } returns activity
+            every { qualtrics.evaluateProject(capture(callbackSlot)) } returns Unit
+
+            qualtricsAnalyticsClient.logEvent("event_name", params)
+
+            callbackSlot.captured.run(mockResults)
+
+            verify(exactly = 1) {
+                qualtrics.displayTarget(context, expectedSurveyUrl)
+            }
+            verify(exactly = 0) {
+                qualtrics.display(any())
+            }
+        } finally {
+            unmockkStatic(Uri::class)
         }
     }
 }

--- a/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
@@ -397,7 +397,7 @@ class QualtricsAnalyticsClientTest {
         mockkStatic(Uri::class)
         try {
             val params = mapOf("screen_name" to "Settings")
-            val expectedSurveyUrl = "https://example.qualtrics.com/jfe/form/SV_123?hide_prompt=true"
+            val expectedSurveyUrl = "https://example.com/survey?hide_prompt=true"
             val mockUri = mockk<Uri> {
                 every { query } returns "hide_prompt=true"
             }
@@ -424,6 +424,64 @@ class QualtricsAnalyticsClientTest {
             }
         } finally {
             unmockkStatic(Uri::class)
+        }
+    }
+
+    @Test
+    fun `Given a passed result with no survey url and a failed result with a hide_prompt survey url, when evaluated, then display the prompt without skipping it`() {
+        val params = mapOf("screen_name" to "Settings")
+        val passedResult = mockk<TargetingResult> {
+            every { passed() } returns true
+            every { surveyUrl } returns null
+        }
+        val failedResult = mockk<TargetingResult> {
+            every { passed() } returns false
+            every { surveyUrl } returns "https://example.com/survey?hide_prompt=true"
+        }
+        val mockResults = mapOf("passed_survey" to passedResult, "failed_survey" to failedResult)
+        val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
+
+        every { activityProvider.currentActivity } returns activity
+        every { qualtrics.evaluateProject(capture(callbackSlot)) } returns Unit
+
+        qualtricsAnalyticsClient.logEvent("event_name", params)
+
+        callbackSlot.captured.run(mockResults)
+
+        verify(exactly = 1) {
+            qualtrics.display(activity)
+        }
+        verify(exactly = 0) {
+            qualtrics.displayTarget(any(), any())
+        }
+    }
+
+    @Test
+    fun `Given a passed result with a survey url and a failed result with a hide_prompt survey url, when evaluated, then display the prompt without skipping it`() {
+        val params = mapOf("screen_name" to "Settings")
+        val passedResult = mockk<TargetingResult> {
+            every { passed() } returns true
+            every { surveyUrl } returns "https://example.com/survey"
+        }
+        val failedResult = mockk<TargetingResult> {
+            every { passed() } returns false
+            every { surveyUrl } returns "https://example.com/survey?hide_prompt=true"
+        }
+        val mockResults = mapOf("passed_survey" to passedResult, "failed_survey" to failedResult)
+        val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
+
+        every { activityProvider.currentActivity } returns activity
+        every { qualtrics.evaluateProject(capture(callbackSlot)) } returns Unit
+
+        qualtricsAnalyticsClient.logEvent("event_name", params)
+
+        callbackSlot.captured.run(mockResults)
+
+        verify(exactly = 1) {
+            qualtrics.display(activity)
+        }
+        verify(exactly = 0) {
+            qualtrics.displayTarget(any(), any())
         }
     }
 }


### PR DESCRIPTION
This change allows Qualtrics survey authors to bypass a survey prompt by appending a query string parameter to the survey URL. 

This is configured in the Qualtrics eXperience Manager (XM) tool as follows...

### Inside the survey

Add the `hide_prompt` embedded data, so the survey knows that this field exists...

<img width="1244" height="753" alt="Screenshot 2026-08-07 at 15 12 03" src="https://github.com/user-attachments/assets/be49b5cd-fb12-4f67-a993-a2f79e8dfda4" />

Example URLs

- Embedded survey: `https://gdstrial.qualtrics.com/jfe/form/SV_3z0911Wln94GMse?Q_CHL=si_appsdk&fb_session_id=1786107706&fb_user_pseudo_id=c7d6111ee2b55858e9fbbf2144350203`
- Survey with prompt: `https://gdstrial.qualtrics.com/jfe/form/SV_3xyJtQMMpZprDYG?Q_CHL=si_appsdk&fb_user_pseudo_id=c7d6111ee2b55858e9fbbf2144350203&fb_session_id=1786107706`

### Inside the intercept

Add the `hide_prompt` static embedded data field and set it to `true`

<img width="2032" height="1162" alt="Screenshot 2026-08-07 at 15 12 58" src="https://github.com/user-attachments/assets/7a37283e-0688-4a2b-91c4-e7dafc58e234" />

Example URLs

- Survey without prompt:  `https://gdstrial.qualtrics.com/jfe/form/SV_d6fDGXtifOAPV2u?Q_CHL=si_appsdk&fb_user_pseudo_id=c7d6111ee2b55858e9fbbf2144350203&fb_session_id=1786107706&hide_prompt=true`

### The result

Here the Edit Topics button fires an embedded survey, and the Chat screen view fires a survey with a prompt. However, a Settings screen view bypasses the prompt and takes the user directly to the survey itself.

[Screen_recording_20260807_155237.webm](https://github.com/user-attachments/assets/7293d086-7436-48e8-ae25-2e3639af37c9)


