### PR TITLE
GOVUKAPP-3839 Google Play 16KB devices crash warning

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ adaptiveAndroid = "1.2.0"
 hilt = "2.57.2"
 ksp = "2.0.21-1.0.28"
 
-datastorePreferences = "1.2.0"
+datastorePreferences = "1.2.1"
 googlePlayServices = "4.4.4"
 crashlytics = "3.0.6"
 

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -24,6 +24,7 @@
          <trusted-key id="0785B3EFF60B1B1BEA94E0BB7C25280EAE63EBE5" group="org.apache.httpcomponents"/>
          <trusted-key id="0CC641C3A62453AB390066C4A41F13C999945293" group="commons-logging" name="commons-logging"/>
          <trusted-key id="0D35D3F60078655126908E8AF3D1600878E85A3D" group="io.netty"/>
+         <trusted-key id="0E225917414670F4442C250DFD533C07C264648F" group="androidx.datastore"/>
          <trusted-key id="0F06FF86BEEAF4E71866EE5232EE5355A6BC6E42">
             <trusting group="androidx.activity"/>
             <trusting group="androidx.annotation"/>


### PR DESCRIPTION
# Title

Looks like DataStore v1.2.0 is causing the issue https://issuetracker.google.com/issues/476745201.
Upgraded DataStore lib to 1.2.1, APK analyzer on release build shows no warning.






## JIRA ticket(s)
  - [GOVUKAPP-3839](https://govukverify.atlassian.net/browse/GOVUKAPP-3839)


## Screenshots

| Before | After |
|--------|-------|
|  <img width="1089" height="504" alt="Screenshot 2026-08-21 at 16 12 20" src="https://github.com/user-attachments/assets/d4467ff6-e01c-4e9e-9318-b0814ef68ebd" /> |  <img width="1101" height="502" alt="Screenshot 2026-08-21 at 16 24 37" src="https://github.com/user-attachments/assets/c944c729-abc8-4d23-ba19-01b9f7b9b9d7" />    |

