### PR TITLE
GOVUKAPP-3825 Update focus order using keyboard

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
@@ -197,8 +197,7 @@ fun Title(
             text = title,
             modifier = Modifier
                 .padding(horizontal = GovUkTheme.spacing.medium)
-                .semantics { heading() }
-                .focusable(),
+                .semantics { heading() },
             color = GovUkTheme.colourScheme.textAndIcons.header
         )
 


### PR DESCRIPTION
# Update focus order using keyboard

- Remove 'focusable' Modifier element from 'Title' UI component as redundant and causing keyboard tabbing to focus on a non-interactive UI element.

## JIRA ticket(s)
  - [GOVUKAPP-3825](https://govukverify.atlassian.net/browse/GOVUKAPP-3825)