### PR TITLE
GOVUKAPP-3944 : Qualtrics - add ability to skip Thank You page

### DIFF
--- a/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
@@ -105,13 +105,16 @@ class QualtricsAnalyticsClient @Inject constructor(
 
             val targetResult = passedResults.values.filterNotNull().firstOrNull()
             val surveyUrl = targetResult?.surveyUrl.orEmpty()
-            val skipPrompt = targetResult?.surveyUrl?.toUri()?.query?.contains("hide_prompt=true") == true
+            val uri = targetResult?.surveyUrl?.toUri()
+            val skipPrompt = uri?.getQueryParameter("hide_prompt") == "true"
+            val autoCloseAtEndOfSurvey = uri?.getQueryParameter("auto_close") == "true"
 
             if (skipPrompt) {
-                qualtrics.displayTarget(context, surveyUrl)
+                qualtrics.displayTarget(context, surveyUrl, autoCloseAtEndOfSurvey)
             } else {
-                qualtrics.display(activity)
+                qualtrics.display(activity, autoCloseAtEndOfSurvey)
             }
+
             onSurveyShown?.invoke(results)
         }
     }

--- a/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
@@ -265,7 +265,7 @@ class QualtricsAnalyticsClientTest {
         callbackSlot.captured.run(mockResults)
 
         verify(exactly = 1) {
-            qualtrics.display(activity)
+            qualtrics.display(activity, false)
         }
     }
 
@@ -362,7 +362,7 @@ class QualtricsAnalyticsClientTest {
         callbackSlot.captured.run(mockResults)
 
         verify(exactly = 1) {
-            qualtrics.display(activity)
+            qualtrics.display(activity, false)
         }
     }
 
@@ -399,7 +399,8 @@ class QualtricsAnalyticsClientTest {
             val params = mapOf("screen_name" to "Settings")
             val expectedSurveyUrl = "https://example.com/survey?hide_prompt=true"
             val mockUri = mockk<Uri> {
-                every { query } returns "hide_prompt=true"
+                every { getQueryParameter("hide_prompt") } returns "true"
+                every { getQueryParameter("auto_close") } returns null
             }
             every { expectedSurveyUrl.toUri() } returns mockUri
             val result = mockk<TargetingResult> {
@@ -417,10 +418,10 @@ class QualtricsAnalyticsClientTest {
             callbackSlot.captured.run(mockResults)
 
             verify(exactly = 1) {
-                qualtrics.displayTarget(context, expectedSurveyUrl)
+                qualtrics.displayTarget(context, expectedSurveyUrl, false)
             }
             verify(exactly = 0) {
-                qualtrics.display(any())
+                qualtrics.display(any(), any())
             }
         } finally {
             unmockkStatic(Uri::class)
@@ -449,10 +450,10 @@ class QualtricsAnalyticsClientTest {
         callbackSlot.captured.run(mockResults)
 
         verify(exactly = 1) {
-            qualtrics.display(activity)
+            qualtrics.display(activity, false)
         }
         verify(exactly = 0) {
-            qualtrics.displayTarget(any(), any())
+            qualtrics.displayTarget(any(), any(), any())
         }
     }
 
@@ -478,10 +479,140 @@ class QualtricsAnalyticsClientTest {
         callbackSlot.captured.run(mockResults)
 
         verify(exactly = 1) {
-            qualtrics.display(activity)
+            qualtrics.display(activity, false)
         }
         verify(exactly = 0) {
-            qualtrics.displayTarget(any(), any())
+            qualtrics.displayTarget(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `Given an event and the survey url contains auto_close=true but not hide_prompt=true, then display prompt and auto close at the end`() {
+        mockkStatic(Uri::class)
+        try {
+            val params = mapOf("screen_name" to "Settings")
+            val expectedSurveyUrl = "https://example.com/survey?auto_close=true"
+            val mockUri = mockk<Uri> {
+                every { getQueryParameter("hide_prompt") } returns null
+                every { getQueryParameter("auto_close") } returns "true"
+            }
+            every { expectedSurveyUrl.toUri() } returns mockUri
+            val result = mockk<TargetingResult> {
+                every { passed() } returns true
+                every { surveyUrl } returns expectedSurveyUrl
+            }
+            val mockResults = mapOf("survey" to result)
+            val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
+
+            every { activityProvider.currentActivity } returns activity
+            every { qualtrics.evaluateProject(capture(callbackSlot)) } returns Unit
+
+            qualtricsAnalyticsClient.logEvent("event_name", params)
+
+            callbackSlot.captured.run(mockResults)
+
+            verify(exactly = 1) {
+                qualtrics.display(activity, true)
+            }
+            verify(exactly = 0) {
+                qualtrics.displayTarget(any(), any(), any())
+            }
+        } finally {
+            unmockkStatic(Uri::class)
+        }
+    }
+
+    @Test
+    fun `Given an event and the survey url contains both hide_prompt=true and auto_close=true, then display the survey and auto close at the end`() {
+        mockkStatic(Uri::class)
+        try {
+            val params = mapOf("screen_name" to "Settings")
+            val expectedSurveyUrl = "https://example.com/survey?hide_prompt=true&auto_close=true"
+            val mockUri = mockk<Uri> {
+                every { getQueryParameter("hide_prompt") } returns "true"
+                every { getQueryParameter("auto_close") } returns "true"
+            }
+            every { expectedSurveyUrl.toUri() } returns mockUri
+            val result = mockk<TargetingResult> {
+                every { passed() } returns true
+                every { surveyUrl } returns expectedSurveyUrl
+            }
+            val mockResults = mapOf("survey" to result)
+            val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
+
+            every { activityProvider.currentActivity } returns activity
+            every { qualtrics.evaluateProject(capture(callbackSlot)) } returns Unit
+
+            qualtricsAnalyticsClient.logEvent("event_name", params)
+
+            callbackSlot.captured.run(mockResults)
+
+            verify(exactly = 1) {
+                qualtrics.displayTarget(context, expectedSurveyUrl, true)
+            }
+            verify(exactly = 0) {
+                qualtrics.display(any(), any())
+            }
+        } finally {
+            unmockkStatic(Uri::class)
+        }
+    }
+
+    @Test
+    fun `Given a passed result with no survey url and a failed result with a auto_close survey url, when evaluated, then auto close`() {
+        val params = mapOf("screen_name" to "Settings")
+        val passedResult = mockk<TargetingResult> {
+            every { passed() } returns true
+            every { surveyUrl } returns null
+        }
+        val failedResult = mockk<TargetingResult> {
+            every { passed() } returns false
+            every { surveyUrl } returns "https://example.com/survey?auto_close=true"
+        }
+        val mockResults = mapOf("passed_survey" to passedResult, "failed_survey" to failedResult)
+        val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
+
+        every { activityProvider.currentActivity } returns activity
+        every { qualtrics.evaluateProject(capture(callbackSlot)) } returns Unit
+
+        qualtricsAnalyticsClient.logEvent("event_name", params)
+
+        callbackSlot.captured.run(mockResults)
+
+        verify(exactly = 1) {
+            qualtrics.display(activity, false)
+        }
+        verify(exactly = 0) {
+            qualtrics.displayTarget(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `Given a passed result with a survey url and a failed result with a auto_close survey url, when evaluated, then auto close`() {
+        val params = mapOf("screen_name" to "Settings")
+        val passedResult = mockk<TargetingResult> {
+            every { passed() } returns true
+            every { surveyUrl } returns "https://example.com/survey"
+        }
+        val failedResult = mockk<TargetingResult> {
+            every { passed() } returns false
+            every { surveyUrl } returns "https://example.com/survey?auto_close=true"
+        }
+        val mockResults = mapOf("passed_survey" to passedResult, "failed_survey" to failedResult)
+        val callbackSlot = slot<IQualtricsProjectEvaluationCallback>()
+
+        every { activityProvider.currentActivity } returns activity
+        every { qualtrics.evaluateProject(capture(callbackSlot)) } returns Unit
+
+        qualtricsAnalyticsClient.logEvent("event_name", params)
+
+        callbackSlot.captured.run(mockResults)
+
+        verify(exactly = 1) {
+            qualtrics.display(activity, false)
+        }
+        verify(exactly = 0) {
+            qualtrics.displayTarget(any(), any(), any())
         }
     }
 }

--- a/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
@@ -559,7 +559,7 @@ class QualtricsAnalyticsClientTest {
     }
 
     @Test
-    fun `Given a passed result with no survey url and a failed result with a auto_close survey url, when evaluated, then auto close`() {
+    fun `Given a passed result with no survey url and a failed result with a auto_close survey url, when evaluated, then do not auto close the survey`() {
         val params = mapOf("screen_name" to "Settings")
         val passedResult = mockk<TargetingResult> {
             every { passed() } returns true
@@ -588,7 +588,7 @@ class QualtricsAnalyticsClientTest {
     }
 
     @Test
-    fun `Given a passed result with a survey url and a failed result with a auto_close survey url, when evaluated, then auto close`() {
+    fun `Given a passed result with a survey url and a failed result with a auto_close survey url, when evaluated, then do not auto close the survey`() {
         val params = mapOf("screen_name" to "Settings")
         val passedResult = mockk<TargetingResult> {
             every { passed() } returns true


### PR DESCRIPTION
## Setup

The `auto_close=true` query string parameter is setup as embedded data in the Qualtrics eXperience Manager tool. This is passed in with a passing survey's is found and `evaluateProject` is called. 

## Qualtrics mobile SDK v2 docs

- [display](https://api.qualtrics.com/46487d8599b17-app-feedback-android-api-reference#display)
- [displaytarget](https://api.qualtrics.com/46487d8599b17-app-feedback-android-api-reference#displaytarget)

## Video

[Screen_recording_20260827_114016.webm](https://github.com/user-attachments/assets/902644a7-be40-48c5-a8e7-dbea551f01db)


## JIRA ticket(s)
  - [GOVUKAPP-3944](https://govukverify.atlassian.net/browse/GOVUKAPP-3944)
