### PR TITLE
feat: NOT-410: show user's subscribed countries on Travel topic

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -603,7 +603,9 @@ private fun GovUkNavHost(
                                 .padding(horizontal = GovUkTheme.spacing.medium),
                             verticalArrangement = Arrangement.spacedBy(GovUkTheme.spacing.medium)
                         ) {
-                            TravelAlertsWidget()
+                            TravelAlertsWidget { url ->
+                                externalLauncher.launch(url) { showBrowserNotFoundAlert = true }
+                            }
                         }
                     }
                 },

--- a/feature/messages/build.gradle.kts
+++ b/feature/messages/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(projects.analytics)
     implementation(projects.design)
     implementation(projects.data)
+    implementation(projects.govkit)
     implementation(projects.feature.dvla)
 
     implementation(libs.androidx.navigation.compose)

--- a/feature/messages/src/main/kotlin/uk/gov/govuk/messages/data/model/Notification.kt
+++ b/feature/messages/src/main/kotlin/uk/gov/govuk/messages/data/model/Notification.kt
@@ -2,11 +2,6 @@ package uk.gov.govuk.messages.data.model
 
 import com.google.gson.annotations.SerializedName
 import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.format.TextStyle
-import java.time.temporal.ChronoUnit
-import java.util.Locale
 
 data class MessageGroups(val recent: List<Message>, val older: List<Message>)
 
@@ -46,69 +41,5 @@ data class Notification(
     val isUnread: Boolean
         get() = status != "READ"
 
-    /**
-        Formats a date to match the rules for Message List
-
-        Today -> Today, 9:45pm
-
-        Yesterday -> Yesterday
-
-        Last 7 days -> Tuesday
-
-        Else -> 7 December
-     */
-    val formattedDate: String
-        get() {
-
-            val london = ZoneId.of("Europe/London")
-            val zonedSelf = date.atZone(london)
-            val today = Instant.now().atZone(london)
-
-            val isToday = zonedSelf.toLocalDate() == today.toLocalDate()
-            val isYesterday = zonedSelf.toLocalDate() == today.toLocalDate().minusDays(1)
-            val daysAgo = ChronoUnit.DAYS.between(zonedSelf.toLocalDate(), today.toLocalDate())
-
-            return when {
-                isToday -> {
-                    val formatter = DateTimeFormatter.ofPattern("'Today,' h:mma", Locale.getDefault())
-                        .withZone(london)
-                    formatter.format(date)
-                        .replace("AM", "am")
-                        .replace("PM", "pm")
-                }
-                isYesterday -> "Yesterday"
-                daysAgo < 7 -> {
-                    zonedSelf.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
-                }
-                else -> {
-                    val formatter = DateTimeFormatter.ofPattern("d MMMM", Locale.getDefault())
-                        .withZone(london)
-                    formatter.format(date)
-                }
-            }
-        }
-
-    val detailFormattedDate: String
-        get() {
-            val london = ZoneId.of("Europe/London")
-            val zonedSelf = date.atZone(london)
-            val today = Instant.now().atZone(london)
-
-            val isToday = zonedSelf.toLocalDate() == today.toLocalDate()
-            val isYesterday = zonedSelf.toLocalDate() == today.toLocalDate().minusDays(1)
-
-            val pattern = when {
-                isToday -> "'Today,' h:mma"
-                isYesterday -> "'Yesterday,' h:mma"
-                else -> "d MMMM, h:mma"
-            }
-
-            val formatter = DateTimeFormatter.ofPattern(pattern, Locale.getDefault())
-                .withZone(london)
-
-            return formatter.format(date)
-                .replace("AM", "am")
-                .replace("PM", "pm")
-        }
 
 }

--- a/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
+++ b/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.messages.ui
 
+import uk.gov.govuk.govkit.date.toRelativeDateTime
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -240,7 +241,7 @@ private fun MessagesDetailScreenLoaded(
 ) {
     val headerContentDescription = stringResource(
         R.string.notification_detail_header_content_description,
-        message.detailFormattedDate,
+        message.date.toRelativeDateTime(),
         message.metadata.sender.displayName
     )
 
@@ -264,7 +265,7 @@ private fun MessagesDetailScreenLoaded(
                     contentDescription = headerContentDescription
                 }) {
             BodyRegularLabel(
-                message.detailFormattedDate,
+                message.date.toRelativeDateTime(),
                 Modifier.padding(bottom = 4.dp),
                 GovUkTheme.colourScheme.textAndIcons.secondary
             )

--- a/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.messages.ui
 
+import uk.gov.govuk.govkit.date.toRelativeDate
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -283,7 +284,7 @@ private fun NotificationRow(
             )
 
             Text(
-                message.formattedDate,
+                message.date.toRelativeDate(),
                 color = GovUkTheme.colourScheme.textAndIcons.secondary,
                 style = subtitleStyle ,
                 maxLines = 1,

--- a/feature/travelalerts/build.gradle.kts
+++ b/feature/travelalerts/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(projects.analytics)
     implementation(projects.design)
     implementation(projects.data)
+    implementation(projects.govkit)
 
     implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.androidx.compose.bom))

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepo.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepo.kt
@@ -1,6 +1,7 @@
 package uk.gov.govuk.travelalerts.data
 
 import uk.gov.govuk.data.model.Result
+import uk.gov.govuk.travelalerts.data.model.Country
 import uk.gov.govuk.travelalerts.data.model.Group
 import java.time.Instant
 
@@ -10,4 +11,5 @@ interface DateProvider {
 
 interface TravelAlertsRepo {
     suspend fun getGroups(): Result<List<Group>>
+    suspend fun getCountries(): Result<List<Country>>
 }

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoImpl.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoImpl.kt
@@ -1,13 +1,16 @@
 package uk.gov.govuk.travelalerts.data
 
+import retrofit2.Response
 import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.data.model.Result.Success
 import uk.gov.govuk.data.remote.safeAuthApiCall
+import uk.gov.govuk.travelalerts.data.model.Country
 import uk.gov.govuk.travelalerts.data.remote.TravelAlertsApi
 import uk.gov.govuk.travelalerts.data.model.Group
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -29,6 +32,7 @@ internal class TravelAlertsRepoImpl @Inject constructor(
     }
 
     private var groups: CacheEntry<List<Group>>? = null
+    private var countries: CacheEntry<List<Country>>? = null
 
     override suspend fun getGroups(): Result<List<Group>> {
         val currGroups = groups
@@ -43,6 +47,31 @@ internal class TravelAlertsRepoImpl @Inject constructor(
 
         if (res is Success) {
             groups = CacheEntry(res.value)
+        }
+
+        return res
+    }
+
+    override suspend fun getCountries(): Result<List<Country>> {
+        val currCountries = countries
+
+        if (currCountries != null && !currCountries.hasExpired(dateProvider.date)) {
+            return Success(currCountries.value)
+        }
+
+        // TODO Implement this real API
+        val res = safeAuthApiCall(apiCall = {
+            Response.success(
+                listOf(
+                    Country("France", "france", Instant.now().toString()),
+                    Country("Spain", "spain", Instant.now().minus(1, ChronoUnit.DAYS).toString()),
+                    Country("Germany", "germany", Instant.now().minus(7, ChronoUnit.DAYS).toString())
+                )
+            )
+        }, authRepo = authRepo)
+
+        if (res is Success) {
+            countries = CacheEntry(res.value)
         }
 
         return res

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/model/Country.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/model/Country.kt
@@ -1,0 +1,16 @@
+package uk.gov.govuk.travelalerts.data.model
+
+import com.google.gson.annotations.SerializedName
+import java.time.Instant
+
+data class Country(
+    @SerializedName("Name")
+    val name: String,
+    @SerializedName("Slug")
+    val slug: String,
+    @SerializedName("LastUpdated")
+    val rawLastUpdated: String
+) {
+    val date: Instant
+        get() = Instant.parse(rawLastUpdated)
+}

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/TravelAlertsWidget.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/TravelAlertsWidget.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -22,22 +25,29 @@ import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.CardListItem
 import uk.gov.govuk.design.ui.component.CentredCardWithIcon
+import uk.gov.govuk.design.ui.component.ExternalLinkListItem
 import uk.gov.govuk.design.ui.component.ExtraLargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.ExtraSmallVerticalSpacer
 import uk.gov.govuk.design.ui.component.LoaderCard
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.SectionHeadingLabel
 import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
+import uk.gov.govuk.design.ui.model.SectionHeadingLabelButton
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.travelalerts.R
 
 @Composable
-fun TravelAlertsWidget () {
+fun TravelAlertsWidget (launchBrowser: (String) -> Unit) {
     val viewModel: TravelAlertsWidgetViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    when (uiState) {
+    when (val state = uiState) {
         TravelAlertsWidgetViewModel.State.Loading -> TravelAlertsLoading()
-        TravelAlertsWidgetViewModel.State.Loaded -> TravelAlertsLoaded()
+        TravelAlertsWidgetViewModel.State.Empty -> TravelAlertsEmpty()
+        is TravelAlertsWidgetViewModel.State.Loaded -> TravelAlertsLoaded(state.rows) { row ->
+            viewModel.onRowClick(row)
+            launchBrowser(row.link)
+        }
         TravelAlertsWidgetViewModel.State.Error -> TravelAlertsError()
     }
 
@@ -47,7 +57,15 @@ fun TravelAlertsWidget () {
 }
 
 @Composable
-private fun TravelAlertsLoaded() {
+private fun TravelAlertsLoading() {
+    Column {
+        LoaderCard(modifier = Modifier.fillMaxWidth())
+        SmallVerticalSpacer()
+    }
+}
+
+@Composable
+private fun TravelAlertsEmpty() {
     CentredCardWithIcon(
         onClick = { },
         icon = uk.gov.govuk.design.R.drawable.ic_add,
@@ -60,10 +78,30 @@ private fun TravelAlertsLoaded() {
 }
 
 @Composable
-private fun TravelAlertsLoading() {
+private fun TravelAlertsLoaded(
+    rows: List<TravelAlertsWidgetViewModel.LoadedRow>,
+    onRowClick: (TravelAlertsWidgetViewModel.LoadedRow) -> Unit
+) {
     Column {
-        LoaderCard(modifier = Modifier.fillMaxWidth())
-        SmallVerticalSpacer()
+        SectionHeadingLabel(
+            title3 = stringResource(R.string.loaded_heading),
+            button = SectionHeadingLabelButton(
+                title = stringResource(R.string.loaded_button_edit),
+                altText = stringResource(R.string.loaded_button_edit),
+                onClick = { /* Not implemented yet */ }
+            )
+        )
+
+        rows.forEachIndexed { index, row ->
+            ExternalLinkListItem(
+                title = row.headline,
+                onClick = { onRowClick(row) },
+                modifier = Modifier.semantics(mergeDescendants = true) { role = Role.Button },
+                description = row.subtitle,
+                isFirst = index == 0,
+                isLast = index == rows.lastIndex
+            )
+        }
     }
 }
 
@@ -109,17 +147,30 @@ private fun TravelAlertsError() {
 
 @Composable
 @PreviewLightDark
-fun TravelAlertsWidgetLoadedPreview() {
+private fun TravelAlertsLoadingPreview() {
     GovUkTheme {
-        TravelAlertsLoaded()
+        TravelAlertsLoading()
     }
 }
 
 @Composable
 @PreviewLightDark
-private fun TravelAlertsLoadingPreview() {
+fun TravelAlertsWidgetEmptyPreview() {
     GovUkTheme {
-        TravelAlertsLoading()
+        TravelAlertsEmpty()
+    }
+}
+
+@Composable
+@PreviewLightDark
+fun TravelAlertsWidgetLoadedPreview() {
+    GovUkTheme {
+        TravelAlertsLoaded(
+            listOf(
+                TravelAlertsWidgetViewModel.LoadedRow("Mock 1", "Updated on 12th September 26", "test"),
+                TravelAlertsWidgetViewModel.LoadedRow("Mock 2", "Updated on 13th September 26", "test")
+            )
+        ) { }
     }
 }
 

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/TravelAlertsWidgetViewModel.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/TravelAlertsWidgetViewModel.kt
@@ -3,34 +3,69 @@ package uk.gov.govuk.travelalerts.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.data.model.Result
+import uk.gov.govuk.govkit.date.toRelativeDate
 import uk.gov.govuk.travelalerts.data.TravelAlertsRepo
+import uk.gov.govuk.travelalerts.data.model.Country
 import javax.inject.Inject
 
 @HiltViewModel
-class TravelAlertsWidgetViewModel @Inject constructor(private val travelAlertsRepo: TravelAlertsRepo) : ViewModel() {
+class TravelAlertsWidgetViewModel @Inject constructor(
+    private val travelAlertsRepo: TravelAlertsRepo,
+    private val analyticsClient: AnalyticsClient
+) : ViewModel() {
     sealed class State {
         data object Loading: State()
-        data object Loaded: State()
+        data class Loaded(val rows: List<LoadedRow>): State()
+        data object Empty: State()
         data object Error: State()
     }
+
+    data class LoadedRow(val headline: String, val subtitle: String, val link: String)
 
     private val _uiState: MutableStateFlow<State> =
         MutableStateFlow(State.Loading)
     val uiState = _uiState.asStateFlow()
 
+    fun onRowClick(row: LoadedRow) {
+        analyticsClient.widgetClick(
+            text = row.headline,
+            url = row.link,
+            external = true,
+            section = SECTION
+        )
+    }
+
     fun onPageView() {
         viewModelScope.launch {
             _uiState.value = State.Loading
-            val res = travelAlertsRepo.getGroups()
-            when (res) {
-                is Result.Success<*> -> _uiState.value = State.Loaded
-                else -> _uiState.value = State.Error
+            val groupsRes = travelAlertsRepo.getGroups()
+            val countriesRes = travelAlertsRepo.getCountries()
+
+            if (groupsRes is Result.Success && countriesRes is Result.Success) {
+                val countriesBySlug = countriesRes.value.associateBy(Country::slug)
+                val rows = groupsRes.value.mapNotNull { group ->
+                    countriesBySlug[group.group]?.let { country ->
+                        LoadedRow(
+                            headline = country.name,
+                            subtitle = country.date.toRelativeDate(),
+                            // TODO Would rather this wasn't hard-coded, but not 100% if it's coming back whole off the API
+                            link = "https://www.gov.uk/foreign-travel-advice/${country.slug}"
+                        )
+                    }
+                }.sortedBy { it.headline }
+                _uiState.value = if (rows.isEmpty()) State.Empty else State.Loaded(rows)
+            } else {
+                _uiState.value = State.Error
             }
         }
+    }
+
+    companion object {
+        private const val SECTION = "Travel Abroad Notifications"
     }
 }

--- a/feature/travelalerts/src/main/res/values/strings.xml
+++ b/feature/travelalerts/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="empty_title">Follow countries for updates</string>
     <string name="empty_description">Get messages and notifications when travel advice changes</string>
+    <string name="loaded_heading">Countries you follow</string>
+    <string name="loaded_button_edit">Edit</string>
 </resources>

--- a/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoTest.kt
+++ b/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoTest.kt
@@ -15,6 +15,7 @@ import uk.gov.govuk.travelalerts.data.model.Group
 import uk.gov.govuk.travelalerts.data.remote.TravelAlertsApi
 import uk.gov.govuk.travelalerts.fixtures.TravelAlertsFixtures
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -35,6 +36,8 @@ class TravelAlertsRepoTest {
         travelAlertsRepo = TravelAlertsRepoImpl(api, auth, mockDateProvider)
     }
 
+    // Get Groups
+    
     @Test
     fun `Get groups performs API call`() = runTest {
         travelAlertsRepo.getGroups()
@@ -68,5 +71,27 @@ class TravelAlertsRepoTest {
 
         assertTrue(result is Result.Success)
         assertEquals(TravelAlertsFixtures.mockGroups, (result as Result.Success).value)
+    }
+
+    // Get Countries
+
+    @Test
+    fun `Get countries returns success`() = runTest {
+        val result = travelAlertsRepo.getCountries()
+
+        assertTrue(result is Result.Success)
+    }
+
+    @Test
+    fun `Get countries fetches fresh data when cache expires`() = runTest {
+        // Prime the cache
+        travelAlertsRepo.getCountries()
+
+        every { mockDateProvider.date } returns Instant.now().plus(301, ChronoUnit.SECONDS)
+
+        val result = travelAlertsRepo.getCountries()
+
+        // TODO: once the real API is in place, verify a new API call is made here
+        assertTrue(result is Result.Success)
     }
 }

--- a/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/fixtures/TravelAlertsFixtures.kt
+++ b/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/fixtures/TravelAlertsFixtures.kt
@@ -1,11 +1,18 @@
 package uk.gov.govuk.travelalerts.fixtures
 
+import uk.gov.govuk.travelalerts.data.model.Country
 import uk.gov.govuk.travelalerts.data.model.Group
 
 object TravelAlertsFixtures {
     val mockGroups = listOf(
-        Group(namespace = "ns1", group = "France", subgroup = "region1"),
-        Group(namespace = "ns2", group = "Germany", subgroup = "region2"),
-        Group(namespace = "ns3", group = "Spain", subgroup = "region3")
+        Group(namespace = "ns1", group = "france", subgroup = "region1"),
+        Group(namespace = "ns2", group = "germany", subgroup = "region2"),
+        Group(namespace = "ns3", group = "spain", subgroup = "region3")
+    )
+
+    val mockCountries = listOf(
+        Country(name = "France", slug = "france", rawLastUpdated = "2024-01-01T00:00:00Z"),
+        Country(name = "Germany", slug = "germany", rawLastUpdated = "2024-01-01T00:00:00Z"),
+        Country(name = "Spain", slug = "spain", rawLastUpdated = "2024-01-01T00:00:00Z")
     )
 }

--- a/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/ui/TravelAlertsWidgetViewModelTest.kt
+++ b/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/ui/TravelAlertsWidgetViewModelTest.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.travelalerts.ui
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -9,23 +10,28 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.travelalerts.data.TravelAlertsRepo
+import uk.gov.govuk.travelalerts.data.model.Country
+import uk.gov.govuk.travelalerts.data.model.Group
 import uk.gov.govuk.travelalerts.fixtures.TravelAlertsFixtures
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TravelAlertsWidgetViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val travelAlertsRepo = mockk<TravelAlertsRepo>(relaxed = true)
+    private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
     private lateinit var viewModel: TravelAlertsWidgetViewModel
 
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
-        viewModel = TravelAlertsWidgetViewModel(travelAlertsRepo)
+        viewModel = TravelAlertsWidgetViewModel(travelAlertsRepo, analyticsClient)
     }
 
     @After
@@ -39,17 +45,73 @@ class TravelAlertsWidgetViewModelTest {
     }
 
     @Test
-    fun `Given page view, when repo succeeds, then state is Loaded`() = runTest {
+    fun `Given page view, when both repos succeed, then state is Loaded with matched rows`() = runTest {
         coEvery { travelAlertsRepo.getGroups() } returns Result.Success(TravelAlertsFixtures.mockGroups)
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
 
         viewModel.onPageView()
 
-        assertTrue(viewModel.uiState.value is TravelAlertsWidgetViewModel.State.Loaded)
+        val state = viewModel.uiState.value as TravelAlertsWidgetViewModel.State.Loaded
+        assertEquals(TravelAlertsFixtures.mockCountries.size, state.rows.size)
+        assertEquals("France", state.rows[0].headline)
+        assertEquals("https://www.gov.uk/foreign-travel-advice/france", state.rows[0].link)
     }
 
     @Test
-    fun `Given page view, when repo fails, then state is Error`() = runTest {
+    fun `Given page view, when both repos succeed, then rows are sorted by country name`() = runTest {
+        val unsortedGroups = listOf(
+            Group(namespace = "ns1", group = "spain", subgroup = "daily"),
+            Group(namespace = "ns2", group = "france", subgroup = "daily"),
+            Group(namespace = "ns3", group = "germany", subgroup = "daily"),
+        )
+        val unsortedCountries = listOf(
+            Country(name = "Spain", slug = "spain", rawLastUpdated = "2024-01-01T00:00:00Z"),
+            Country(name = "France", slug = "france", rawLastUpdated = "2024-01-01T00:00:00Z"),
+            Country(name = "Germany", slug = "germany", rawLastUpdated = "2024-01-01T00:00:00Z"),
+        )
+        coEvery { travelAlertsRepo.getGroups() } returns Result.Success(unsortedGroups)
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(unsortedCountries)
+
+        viewModel.onPageView()
+
+        val state = viewModel.uiState.value as TravelAlertsWidgetViewModel.State.Loaded
+        assertEquals(listOf("France", "Germany", "Spain"), state.rows.map { it.headline })
+    }
+
+    @Test
+    fun `Given page view, when groups is empty, then state is Empty`() = runTest {
+        coEvery { travelAlertsRepo.getGroups() } returns Result.Success(emptyList())
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
+
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is TravelAlertsWidgetViewModel.State.Empty)
+    }
+
+    @Test
+    fun `Given page view, when no countries match groups, then state is Empty`() = runTest {
+        coEvery { travelAlertsRepo.getGroups() } returns Result.Success(TravelAlertsFixtures.mockGroups)
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(emptyList())
+
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is TravelAlertsWidgetViewModel.State.Empty)
+    }
+
+    @Test
+    fun `Given page view, when groups fails, then state is Error`() = runTest {
         coEvery { travelAlertsRepo.getGroups() } returns Result.ServiceNotResponding(500)
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
+
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is TravelAlertsWidgetViewModel.State.Error)
+    }
+
+    @Test
+    fun `Given page view, when countries fails, then state is Error`() = runTest {
+        coEvery { travelAlertsRepo.getGroups() } returns Result.Success(TravelAlertsFixtures.mockGroups)
+        coEvery { travelAlertsRepo.getCountries() } returns Result.ServiceNotResponding(500)
 
         viewModel.onPageView()
 
@@ -59,9 +121,29 @@ class TravelAlertsWidgetViewModelTest {
     @Test
     fun `Given page view, when offline, then state is Error`() = runTest {
         coEvery { travelAlertsRepo.getGroups() } returns Result.DeviceOffline()
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
 
         viewModel.onPageView()
 
         assertTrue(viewModel.uiState.value is TravelAlertsWidgetViewModel.State.Error)
+    }
+
+    @Test
+    fun `Given row click, then analytics event is fired with correct parameters`() = runTest {
+        coEvery { travelAlertsRepo.getGroups() } returns Result.Success(TravelAlertsFixtures.mockGroups)
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
+        viewModel.onPageView()
+        val state = viewModel.uiState.value as TravelAlertsWidgetViewModel.State.Loaded
+
+        viewModel.onRowClick(state.rows.first { it.headline == "France" })
+
+        verify {
+            analyticsClient.widgetClick(
+                text = "France",
+                url = "https://www.gov.uk/foreign-travel-advice/france",
+                external = true,
+                section = "Travel Abroad Notifications"
+            )
+        }
     }
 }

--- a/govkit/build.gradle.kts
+++ b/govkit/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.compose)
+    alias(libs.plugins.kover)
 }
 
 android {

--- a/govkit/src/main/kotlin/uk/gov/govuk/govkit/date/InstantExt.kt
+++ b/govkit/src/main/kotlin/uk/gov/govuk/govkit/date/InstantExt.kt
@@ -1,0 +1,73 @@
+package uk.gov.govuk.govkit.date
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+private val london = ZoneId.of("Europe/London")
+
+/**
+ * Formats this [Instant] as a human-readable relative date, suitable for use in list views.
+ * Time is only shown when the date is today.
+ *
+ * - Today     → "Today, 9:45pm"
+ * - Yesterday → "Yesterday"
+ * - < 7 days  → "Tuesday"
+ * - Older     → "7 December"
+ *
+ * @param now the reference instant used to compute relative labels; defaults to [Instant.now].
+ */
+fun Instant.toRelativeDate(now: Instant = Instant.now()): String {
+    val zonedSelf = atZone(london)
+    val today = now.atZone(london)
+
+    val isToday = zonedSelf.toLocalDate() == today.toLocalDate()
+    val isYesterday = zonedSelf.toLocalDate() == today.toLocalDate().minusDays(1)
+    val daysAgo = ChronoUnit.DAYS.between(zonedSelf.toLocalDate(), today.toLocalDate())
+
+    return when {
+        isToday -> DateTimeFormatter.ofPattern("'Today,' h:mma", Locale.getDefault())
+            .withZone(london)
+            .format(this)
+            .replace("AM", "am")
+            .replace("PM", "pm")
+        isYesterday -> "Yesterday"
+        daysAgo < 7 -> zonedSelf.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
+        else -> DateTimeFormatter.ofPattern("d MMMM", Locale.getDefault())
+            .withZone(london)
+            .format(this)
+    }
+}
+
+/**
+ * Formats this [Instant] as a human-readable relative date and time, suitable for use in detail
+ * views. Unlike [toRelativeDate], the time component is always included.
+ *
+ * - Today     → "Today, 9:45pm"
+ * - Yesterday → "Yesterday, 9:45pm"
+ * - Older     → "7 December, 9:45pm"
+ *
+ * @param now the reference instant used to compute relative labels; defaults to [Instant.now].
+ */
+fun Instant.toRelativeDateTime(now: Instant = Instant.now()): String {
+    val zonedSelf = atZone(london)
+    val today = now.atZone(london)
+
+    val isToday = zonedSelf.toLocalDate() == today.toLocalDate()
+    val isYesterday = zonedSelf.toLocalDate() == today.toLocalDate().minusDays(1)
+
+    val pattern = when {
+        isToday -> "'Today,' h:mma"
+        isYesterday -> "'Yesterday,' h:mma"
+        else -> "d MMMM, h:mma"
+    }
+
+    return DateTimeFormatter.ofPattern(pattern, Locale.getDefault())
+        .withZone(london)
+        .format(this)
+        .replace("AM", "am")
+        .replace("PM", "pm")
+}

--- a/govkit/src/test/kotlin/uk/gov/govuk/govkit/date/InstantExtTest.kt
+++ b/govkit/src/test/kotlin/uk/gov/govuk/govkit/date/InstantExtTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.govuk.govkit.date
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+
+class InstantExtTest {
+
+    // now = Friday 2026-08-28 13:00 BST (12:00 UTC)
+    private val now = Instant.parse("2026-08-28T12:00:00Z")
+
+    // --- toRelativeDate ---
+
+    @Test
+    fun `toRelativeDate, today, returns Today with time`() {
+        val date = Instant.parse("2026-08-28T09:00:00Z") // 10:00am BST
+        assertEquals("Today, 10:00am", date.toRelativeDate(now))
+    }
+
+    @Test
+    fun `toRelativeDate, yesterday, returns Yesterday`() {
+        val date = Instant.parse("2026-08-27T09:00:00Z")
+        assertEquals("Yesterday", date.toRelativeDate(now))
+    }
+
+    @Test
+    fun `toRelativeDate, within last 7 days, returns day name`() {
+        val date = Instant.parse("2026-08-25T09:00:00Z") // Tuesday
+        assertEquals("Tuesday", date.toRelativeDate(now))
+    }
+
+    @Test
+    fun `toRelativeDate, exactly 7 days ago, returns formatted date`() {
+        val date = Instant.parse("2026-08-21T09:00:00Z") // boundary: daysAgo == 7
+        assertEquals("21 August", date.toRelativeDate(now))
+    }
+
+    @Test
+    fun `toRelativeDate, older, returns formatted date`() {
+        val date = Instant.parse("2026-07-29T09:00:00Z")
+        assertEquals("29 July", date.toRelativeDate(now))
+    }
+
+    // --- toRelativeDateTime ---
+
+    @Test
+    fun `toRelativeDateTime, today, returns Today with time`() {
+        val date = Instant.parse("2026-08-28T09:00:00Z") // 10:00am BST
+        assertEquals("Today, 10:00am", date.toRelativeDateTime(now))
+    }
+
+    @Test
+    fun `toRelativeDateTime, yesterday, returns Yesterday with time`() {
+        val date = Instant.parse("2026-08-27T09:00:00Z") // 10:00am BST
+        assertEquals("Yesterday, 10:00am", date.toRelativeDateTime(now))
+    }
+
+    @Test
+    fun `toRelativeDateTime, older, returns formatted date with time`() {
+        val date = Instant.parse("2026-07-29T09:00:00Z") // 10:00am BST
+        assertEquals("29 July, 10:00am", date.toRelativeDateTime(now))
+    }
+}


### PR DESCRIPTION
# Display the user's subscribed countries for Travel Alerts

Read-only for now as the screen to update the list is in the next ticket

## JIRA ticket(s)
  - [NOT-410](https://gdsgovukagents.atlassian.net/browse/NOT-410)

## Figma
  - [Figma board](https://www.figma.com/design/TJKGPyTt8RnvVTqK9KFijt/Travel-Advice?node-id=3587-45893&m=dev)

## Screen shots

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/78f8bb41-a014-4902-a6eb-79c5a5e18e76" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/6c570e70-2178-43a7-94c0-c28d68b7169e" />


[NOT-410]: https://gdsgovukagents.atlassian.net/browse/NOT-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ