### PR TITLE
GOVUKAPP-3964 Focus indicator for cards

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Card.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Card.kt
@@ -52,6 +52,7 @@ import uk.gov.govuk.design.ui.extension.drawBottomStroke
 import uk.gov.govuk.design.ui.extension.talkBackText
 import uk.gov.govuk.design.ui.extension.withAltText
 import uk.gov.govuk.design.ui.model.CardListItem
+import uk.gov.govuk.design.ui.model.CentredCardColours
 import uk.gov.govuk.design.ui.model.DrillInCardColours
 import uk.gov.govuk.design.ui.model.EmergencyBannerUiType
 import uk.gov.govuk.design.ui.model.FocusableCardColours
@@ -338,6 +339,10 @@ fun CentredCardWithIcon(
     drawBottomStroke: Boolean = true,
     paddingValues: PaddingValues = PaddingValues(vertical = GovUkTheme.spacing.extraLarge)
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val colours = resolveCentredCardColours(isFocused = isFocused)
+
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -350,14 +355,19 @@ fun CentredCardWithIcon(
                     )
                 } else Modifier
             ),
-        colors = CardDefaults.cardColors(containerColor = GovUkTheme.colourScheme.surfaces.list)
+        colors = CardDefaults.cardColors(containerColor = colours.background),
+        onClick = onClick,
+        interactionSource = interactionSource
     ) {
         CentredContentWithIcon(
             icon = icon,
-            modifier = Modifier.clickable(onClick = onClick),
+            modifier = Modifier,
             title = title,
             description = description,
-            paddingValues = paddingValues
+            paddingValues = paddingValues,
+            iconColour = colours.icon,
+            titleColour = colours.title,
+            descriptionColour = colours.description
         )
     }
 }
@@ -371,7 +381,10 @@ fun CentredContentWithIcon(
     paddingValues: PaddingValues = PaddingValues(
         vertical = GovUkTheme.spacing.extraLarge,
         horizontal = GovUkTheme.spacing.extraLarge
-    )
+    ),
+    iconColour: Color = GovUkTheme.colourScheme.textAndIcons.icon,
+    titleColour: Color = GovUkTheme.colourScheme.textAndIcons.primary,
+    descriptionColour: Color = GovUkTheme.colourScheme.textAndIcons.secondary
 ) {
     Column(
         modifier = modifier
@@ -384,7 +397,7 @@ fun CentredContentWithIcon(
             painterResource(icon),
             contentDescription = null,
             modifier = Modifier.size(32.dp),
-            tint = GovUkTheme.colourScheme.textAndIcons.icon
+            tint = iconColour
         )
 
         title?.let { title ->
@@ -392,7 +405,7 @@ fun CentredContentWithIcon(
 
             BodyBoldLabel(
                 text = title,
-                color = GovUkTheme.colourScheme.textAndIcons.primary,
+                color = titleColour,
                 modifier = Modifier.clearAndSetSemantics { },
                 textAlign = TextAlign.Center,
             )
@@ -403,11 +416,31 @@ fun CentredContentWithIcon(
 
             BodyRegularLabel(
                 text = description,
-                color = GovUkTheme.colourScheme.textAndIcons.secondary,
+                color = descriptionColour,
                 modifier = Modifier.clearAndSetSemantics { },
                 textAlign = TextAlign.Center,
             )
         }
+    }
+}
+
+@Composable
+private fun resolveCentredCardColours(isFocused: Boolean): CentredCardColours {
+    return if (isFocused) {
+        val focusedTextColour = GovUkTheme.colourScheme.textAndIcons.focused
+        CentredCardColours(
+            background = GovUkTheme.colourScheme.surfaces.focused,
+            title = focusedTextColour,
+            description = focusedTextColour,
+            icon = focusedTextColour
+        )
+    } else {
+        CentredCardColours(
+            background = GovUkTheme.colourScheme.surfaces.list,
+            title = GovUkTheme.colourScheme.textAndIcons.primary,
+            description = GovUkTheme.colourScheme.textAndIcons.secondary,
+            icon = GovUkTheme.colourScheme.textAndIcons.icon
+        )
     }
 }
 

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/model/Card.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/model/Card.kt
@@ -26,3 +26,10 @@ internal data class DrillInCardColours(
     val icon: Color,
     val stroke: Color
 )
+
+data class CentredCardColours(
+    val background: Color,
+    val title: Color,
+    val description: Color,
+    val icon: Color
+)

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/AddVehicleListItem.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/AddVehicleListItem.kt
@@ -1,21 +1,47 @@
 package uk.gov.govuk.dvla.ui.component
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.dp
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.CardListItem
 import uk.gov.govuk.design.ui.component.SmallHorizontalSpacer
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 
+private data class AddVehicleListItemColours(
+    val background: Color,
+    val text: Color,
+    val icon: Color
+)
+
+@Composable
+private fun resolveAddVehicleListItemColours(isFocused: Boolean): AddVehicleListItemColours {
+    return if (isFocused) {
+        AddVehicleListItemColours(
+            background = GovUkTheme.colourScheme.surfaces.focused,
+            text = GovUkTheme.colourScheme.textAndIcons.focused,
+            icon = GovUkTheme.colourScheme.textAndIcons.focused
+        )
+    } else {
+        AddVehicleListItemColours(
+            background = GovUkTheme.colourScheme.surfaces.list,
+            text = GovUkTheme.colourScheme.textAndIcons.primary,
+            icon = GovUkTheme.colourScheme.textAndIcons.linkPrimary
+        )
+    }
+}
 @Composable
 fun AddVehicleListItem(
     title: String,
@@ -25,12 +51,19 @@ fun AddVehicleListItem(
     isFirst: Boolean = true,
     isLast: Boolean = true
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val colours = resolveAddVehicleListItemColours(isFocused = isFocused)
+
     CardListItem(
         modifier = modifier,
         onClick = onClick,
+        interactionSource = interactionSource,
         isFirst = isFirst,
         isLast = isLast,
-        drawDivider = true
+        drawDivider = true,
+        background = colours.background
     ) {
         Row(
             modifier = Modifier
@@ -41,7 +74,7 @@ fun AddVehicleListItem(
             BodyRegularLabel(
                 text = title,
                 modifier = Modifier.weight(1f),
-                color = GovUkTheme.colourScheme.textAndIcons.primary
+                color = colours.text
             )
 
             SmallHorizontalSpacer()
@@ -49,7 +82,7 @@ fun AddVehicleListItem(
             Icon(
                 painter = painterResource(id = icon),
                 contentDescription = null,
-                tint = GovUkTheme.colourScheme.textAndIcons.linkPrimary
+                tint = colours.icon
             )
         }
     }


### PR DESCRIPTION
# Title

Changed focus indicator for cards when navigating using keyboard tab/arrow keys.

## JIRA ticket(s)
  - [GOVUKAPP-3964](https://govukverify.atlassian.net/browse/GOVUKAPP-3964)

## Figma
  - [Figma board](https://www.figma.com/design/x5i4a5RT0xMhJAcjoIxefb/2025-06-GOV.UK-app-library-v2--UX-refresh?node-id=14123-5629&t=pkxbBXO7OBvdE7wB-1)

## Screenshots
[Screen_recording_20260902_124727.webm](https://github.com/user-attachments/assets/d069ff72-af1b-4bb0-9a03-fbe48e51110e)

<img width="540" height="1212" alt="Screenshot_20260902_123548" src="https://github.com/user-attachments/assets/04580235-fa9d-4c5a-8938-911867db4143" />
<img width="540" height="1212" alt="Screenshot_20260902_124708" src="https://github.com/user-attachments/assets/756700f6-23aa-4766-aaa5-62606c5227bf" />
