### PR TITLE
GOVUKAPP-3828 Navigation with switch control

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Button.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Button.kt
@@ -31,9 +31,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -279,11 +277,7 @@ fun ConnectedButton(
         onClick = onClick,
         interactionSource = interactionSource,
         modifier = modifier
-            .focusable(interactionSource = interactionSource)
-            .clearAndSetSemantics {
-            role = Role.Button
-            contentDescription = altText
-        },
+            .focusable(interactionSource = interactionSource),
         shape = RoundedCornerShape(15.dp),
         colors = buttonColors(
             containerColor = containerColour,
@@ -294,7 +288,10 @@ fun ConnectedButton(
             text = text,
             style = if (active) GovUkTheme.typography.bodyBold else
                 GovUkTheme.typography.bodyRegular,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            modifier = Modifier.semantics {
+                contentDescription = altText
+            }
         )
     }
 }


### PR DESCRIPTION
# Navigation with switch control

- Rework to remove 'clearAndSetSemantics' from segmented controller buttons as it strips attributes used by switch control which stops it focussing on them

## JIRA ticket(s)
  - [GOVUKAPP-3828](https://govukverify.atlassian.net/browse/GOVUKAPP-3828)

Switch control:
https://github.com/user-attachments/assets/076a20dd-bc30-4da4-9c2c-7ae7e621fb16


Talkback:
https://github.com/user-attachments/assets/9e50bea9-0e07-4a3b-9dc8-290a916ad75f

