### PR TITLE
GOVUKAPP-3962 Focus indicator for dialogs

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/terms/ui/TermsScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/terms/ui/TermsScreen.kt
@@ -156,7 +156,7 @@ private fun DenialDialog(
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // TODO GOVUKAPP-3964 use DialogButton
+    // TODO GOVUKAPP-3962 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),

--- a/app/src/main/kotlin/uk/gov/govuk/terms/ui/TermsScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/terms/ui/TermsScreen.kt
@@ -25,6 +25,7 @@ import uk.gov.govuk.R
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.CentreAlignedScreen
+import uk.gov.govuk.design.ui.component.DialogButton
 import uk.gov.govuk.design.ui.component.FixedDoubleButtonGroup
 import uk.gov.govuk.design.ui.component.LargeTitleBoldLabel
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
@@ -156,34 +157,10 @@ private fun DenialDialog(
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // TODO GOVUKAPP-3962 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    onDismiss()
-                    onSignOut()
-                }
-            ) {
-                BodyRegularLabel(
-                    text = stringResource(R.string.terms_dialog_sign_out),
-                    color = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
-                )
-            }
-        },
         modifier = modifier,
-        dismissButton = {
-            TextButton(
-                onClick = onDismiss
-            ) {
-                BodyBoldLabel(
-                    text = stringResource(R.string.terms_dialog_cancel),
-                    color = GovUkTheme.colourScheme.textAndIcons.linkSecondary
-                )
-            }
-        },
         title = {
             BodyBoldLabel(stringResource(R.string.terms_dialog_title))
         },
@@ -193,7 +170,25 @@ private fun DenialDialog(
                 color = GovUkTheme.colourScheme.textAndIcons.secondary
             )
         },
-        containerColor = GovUkTheme.colourScheme.surfaces.alert,
+        confirmButton = {
+            DialogButton(
+                text = stringResource(R.string.terms_dialog_sign_out),
+                onClick = {
+                    onDismiss()
+                    onSignOut()
+                },
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
+            )
+        },
+        dismissButton = {
+            DialogButton(
+                text = stringResource(R.string.terms_dialog_cancel),
+                onClick = onDismiss,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.linkSecondary,
+                isBold = true
+            )
+        },
+        containerColor = GovUkTheme.colourScheme.surfaces.alert
     )
 }
 

--- a/app/src/main/kotlin/uk/gov/govuk/terms/ui/TermsScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/terms/ui/TermsScreen.kt
@@ -156,6 +156,7 @@ private fun DenialDialog(
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // TODO GOVUKAPP-3964 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Alert.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Alert.kt
@@ -18,30 +18,28 @@ fun InfoAlert(
     @StringRes buttonText: Int,
     onDismiss: () -> Unit
 ) {
-    // TODO GOVUKAPP-3962 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
+        title = {
+            BodyBoldLabel(
+                text = stringResource(id = title),
+                color = GovUkTheme.colourScheme.textAndIcons.primary
+            )
+        },
         text = {
-            Column {
-                BodyBoldLabel(
-                    text = stringResource(id = title),
-                    color = GovUkTheme.colourScheme.textAndIcons.primary
-                )
-                MediumVerticalSpacer()
-                BodyRegularLabel(
-                    text = stringResource(id = message),
-                    color = GovUkTheme.colourScheme.textAndIcons.secondary
-                )
-            }
+            BodyRegularLabel(
+                text = stringResource(id = message),
+                color = GovUkTheme.colourScheme.textAndIcons.secondary
+            )
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
-                BodyBoldLabel(
-                    text = stringResource(id = buttonText),
-                    color = GovUkTheme.colourScheme.textAndIcons.linkSecondary
-                )
-            }
+            DialogButton(
+                text = stringResource(id = buttonText),
+                onClick = onDismiss,
+                isBold = true,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.linkSecondary
+            )
         },
         containerColor = GovUkTheme.colourScheme.surfaces.alert
     )

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Alert.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Alert.kt
@@ -18,6 +18,7 @@ fun InfoAlert(
     @StringRes buttonText: Int,
     onDismiss: () -> Unit
 ) {
+    // TODO GOVUKAPP-3964 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Alert.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Alert.kt
@@ -18,7 +18,7 @@ fun InfoAlert(
     @StringRes buttonText: Int,
     onDismiss: () -> Unit
 ) {
-    // TODO GOVUKAPP-3964 use DialogButton
+    // TODO GOVUKAPP-3962 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Button.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Button.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults.buttonColors
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -445,6 +446,39 @@ fun OverflowButton(
             contentDescription = altText,
             tint = iconTint
         )
+    }
+}
+
+@Composable
+fun DialogButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    defaultTextColour: Color = GovUkTheme.colourScheme.textAndIcons.link,
+    isBold: Boolean = false
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val (backgroundColour, textColour) = if (isFocused) {
+        GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+    } else {
+        Color.Transparent to defaultTextColour
+    }
+
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        interactionSource = interactionSource,
+        colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+            containerColor = backgroundColour
+        )
+    ) {
+        if (isBold) {
+            BodyBoldLabel(text = text, color = textColour)
+        } else {
+            BodyRegularLabel(text = text, color = textColour)
+        }
     }
 }
 

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
@@ -219,7 +219,7 @@ private fun ClearMenuItem(
         )
 
         if (openDialog.value) {
-            // TODO GOVUKAPP-3964 use DialogButton
+            // TODO GOVUKAPP-3962 use DialogButton
             AlertDialog(
                 onDismissRequest = { openDialog.value = false },
                 shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
@@ -44,6 +44,7 @@ import uk.gov.govuk.chat.domain.Analytics
 import uk.gov.govuk.config.data.remote.model.ChatUrls
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
+import uk.gov.govuk.design.ui.component.DialogButton
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 
 @Composable
@@ -219,7 +220,6 @@ private fun ClearMenuItem(
         )
 
         if (openDialog.value) {
-            // TODO GOVUKAPP-3962 use DialogButton
             AlertDialog(
                 onDismissRequest = { openDialog.value = false },
                 shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
@@ -238,7 +238,8 @@ private fun ClearMenuItem(
                 confirmButton = {
                     val buttonText = stringResource(id = R.string.clear_dialog_positive_button)
 
-                    TextButton(
+                    DialogButton(
+                        text = buttonText,
                         onClick = {
                             onFunctionItemClicked(
                                 buttonText,
@@ -247,17 +248,16 @@ private fun ClearMenuItem(
                             )
                             onClear()
                             openDialog.value = false
-                        }
-                    ) {
-                        BodyBoldLabel(
-                            text = buttonText,
-                            color = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
-                        )
-                    }
+                        },
+                        isBold = true,
+                        defaultTextColour = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
+                    )
                 },
                 dismissButton = {
                     val buttonText = stringResource(id = R.string.clear_dialog_negative_button)
-                    TextButton(
+
+                    DialogButton(
+                        text = buttonText,
                         onClick = {
                             onFunctionItemClicked(
                                 buttonText,
@@ -265,13 +265,9 @@ private fun ClearMenuItem(
                                 Analytics.ACTION_MENU_CLEAR_NO
                             )
                             openDialog.value = false
-                        }
-                    ) {
-                        BodyRegularLabel(
-                            text = buttonText,
-                            color = GovUkTheme.colourScheme.textAndIcons.link
-                        )
-                    }
+                        },
+                        defaultTextColour = GovUkTheme.colourScheme.textAndIcons.link
+                    )
                 },
                 containerColor = GovUkTheme.colourScheme.surfaces.alert
             )

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
@@ -219,6 +219,7 @@ private fun ClearMenuItem(
         )
 
         if (openDialog.value) {
+            // TODO GOVUKAPP-3964 use DialogButton
             AlertDialog(
                 onDismissRequest = { openDialog.value = false },
                 shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),

--- a/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
+++ b/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
@@ -48,6 +48,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
+import uk.gov.govuk.design.ui.component.DialogButton
 import uk.gov.govuk.design.ui.component.RunOnceLaunchedEffect
 import uk.gov.govuk.design.ui.component.Title1BoldLabel
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -297,35 +298,30 @@ private fun MessagesDetailScreenLoaded(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ConfirmationDialog(onConfirm: () -> Unit, onCancel: () -> Unit) {
-    // TODO GOVUKAPP-3962 use DialogButton
     AlertDialog(
-        shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList), title = {
-        BodyBoldLabel(stringResource(R.string.delete_notification_sheet_title))
-    }, text = {
-        BodyRegularLabel(stringResource(R.string.delete_notification_sheet_body))
-    }, onDismissRequest = {
-        onCancel()
-    }, confirmButton = {
-        TextButton(
-            onClick = {
-                onConfirm()
-            }) {
-            BodyRegularLabel(
-                stringResource(R.string.delete_notification_sheet_confirm),
-                color = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
+        shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
+        title = {
+            BodyBoldLabel(stringResource(R.string.delete_notification_sheet_title))
+        },
+        text = {
+            BodyRegularLabel(stringResource(R.string.delete_notification_sheet_body))
+        },
+        onDismissRequest = onCancel,
+        confirmButton = {
+            DialogButton(
+                text = stringResource(R.string.delete_notification_sheet_confirm),
+                onClick = onConfirm,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
             )
-        }
-    }, dismissButton = {
-        TextButton(
-            onClick = {
-                onCancel()
-            }) {
-            BodyRegularLabel(
-                stringResource(R.string.delete_notification_sheet_cancel),
-                color = GovUkTheme.colourScheme.textAndIcons.linkSecondary
+        },
+        dismissButton = {
+            DialogButton(
+                text = stringResource(R.string.delete_notification_sheet_cancel),
+                onClick = onCancel,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.linkSecondary
             )
-        }
-    }, containerColor = GovUkTheme.colourScheme.surfaces.alert
+        },
+        containerColor = GovUkTheme.colourScheme.surfaces.alert
     )
 }
 

--- a/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
+++ b/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
@@ -297,7 +297,7 @@ private fun MessagesDetailScreenLoaded(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ConfirmationDialog(onConfirm: () -> Unit, onCancel: () -> Unit) {
-    // TODO GOVUKAPP-3964 use DialogButton
+    // TODO GOVUKAPP-3962 use DialogButton
     AlertDialog(
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList), title = {
         BodyBoldLabel(stringResource(R.string.delete_notification_sheet_title))

--- a/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
+++ b/feature/messages/src/main/kotlin/uk/gov/govuk/messages/ui/MessagesDetailScreen.kt
@@ -296,6 +296,7 @@ private fun MessagesDetailScreenLoaded(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ConfirmationDialog(onConfirm: () -> Unit, onCancel: () -> Unit) {
+    // TODO GOVUKAPP-3964 use DialogButton
     AlertDialog(
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList), title = {
         BodyBoldLabel(stringResource(R.string.delete_notification_sheet_title))

--- a/feature/search/src/main/kotlin/uk/gov/govuk/search/ui/PreviousSearches.kt
+++ b/feature/search/src/main/kotlin/uk/gov/govuk/search/ui/PreviousSearches.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
+import uk.gov.govuk.design.ui.component.DialogButton
 import uk.gov.govuk.design.ui.component.ExtraSmallHorizontalSpacer
 import uk.gov.govuk.design.ui.component.ListDivider
 import uk.gov.govuk.design.ui.component.SmallHorizontalSpacer
@@ -200,16 +201,6 @@ private fun RemoveAllConfirmationDialog(
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
-        confirmButton = {
-            TextButton(
-                onClick = onConfirm
-            ) {
-                BodyRegularLabel(
-                    text = stringResource(R.string.remove_confirmation_dialog_button),
-                    color = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
-                )
-            }
-        },
         modifier = modifier,
         title = {
             BodyBoldLabel(stringResource(R.string.remove_confirmation_dialog_title))
@@ -218,6 +209,13 @@ private fun RemoveAllConfirmationDialog(
             BodyRegularLabel(
                 text = stringResource(R.string.remove_confirmation_dialog_message),
                 color = GovUkTheme.colourScheme.textAndIcons.secondary
+            )
+        },
+        confirmButton = {
+            DialogButton(
+                text = stringResource(R.string.remove_confirmation_dialog_button),
+                onClick = onConfirm,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
             )
         },
         containerColor = GovUkTheme.colourScheme.surfaces.alert

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/YourAccountsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/YourAccountsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -25,6 +24,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.ChildPageHeader
+import uk.gov.govuk.design.ui.component.DialogButton
 import uk.gov.govuk.design.ui.component.FixedPrimaryButton
 import uk.gov.govuk.design.ui.component.InternalLinkListItem
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
@@ -227,28 +227,25 @@ private fun RemoveAccountDialog(
             )
         },
         confirmButton = {
-            TextButton(
-                onClick = onConfirm
-            ) {
-                BodyBoldLabel(
-                    text = confirmButtonText,
-                    color = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
-                )
-            }
+            DialogButton(
+                text = confirmButtonText,
+                onClick = onConfirm,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.buttonDestructive,
+                isBold = true
+            )
         },
         dismissButton = {
-            TextButton(
-                onClick = onDismiss
-            ) {
-                BodyRegularLabel(
-                    text = cancelButtonText,
-                    color = GovUkTheme.colourScheme.textAndIcons.linkSecondary
-                )
-            }
+            DialogButton(
+                text = cancelButtonText,
+                onClick = onDismiss,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.linkSecondary,
+                isBold = false
+            )
         },
         containerColor = GovUkTheme.colourScheme.surfaces.alert
     )
 }
+
 
 @Composable
 internal fun RemoveAccountErrorScreen(

--- a/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/VisitedScreen.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.launch
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.ChildPageHeader
+import uk.gov.govuk.design.ui.component.DialogButton
 import uk.gov.govuk.design.ui.component.ExternalLinkListItem
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.RunOnceLaunchedEffect
@@ -213,32 +214,26 @@ private fun RemoveAllConfirmationDialog(
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    onConfirm()
-                    onDismiss()
-                }
-            ) {
-                BodyRegularLabel(
-                    text = stringResource(R.string.visited_items_remove_all_button),
-                    color = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
-                )
-            }
-        },
-        dismissButton = {
-            TextButton(
-                onClick = onDismiss
-            ) {
-                BodyRegularLabel(
-                    text = stringResource(R.string.visited_items_cancel_button),
-                    color = GovUkTheme.colourScheme.textAndIcons.linkSecondary
-                )
-            }
-        },
         modifier = modifier,
         title = {
             BodyBoldLabel(stringResource(R.string.visited_items_remove_all))
+        },
+        confirmButton = {
+            DialogButton(
+                text = stringResource(R.string.visited_items_remove_all_button),
+                onClick = {
+                    onConfirm()
+                    onDismiss()
+                },
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
+            )
+        },
+        dismissButton = {
+            DialogButton(
+                text = stringResource(R.string.visited_items_cancel_button),
+                onClick = onDismiss,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.linkSecondary
+            )
         },
         containerColor = GovUkTheme.colourScheme.surfaces.alert
     )

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/Alerts.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/Alerts.kt
@@ -3,17 +3,15 @@ package uk.gov.govuk.notifications.ui
 import android.content.Context
 import android.content.Intent
 import android.provider.Settings
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.app.NotificationManagerCompat
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
-import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.DialogButton
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.notifications.R
 
@@ -40,51 +38,44 @@ internal fun NotificationsSettingsAlert(
                 R.string.notifications_alert_message_on
         )
 
-    // TODO GOVUKAPP-3964 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
+        title = {
+            BodyBoldLabel(
+                text = alertTitle,
+                color = GovUkTheme.colourScheme.textAndIcons.primary
+            )
+        },
         text = {
-            Column {
-                BodyBoldLabel(
-                    text = alertTitle,
-                    color = GovUkTheme.colourScheme.textAndIcons.primary
-                )
-                MediumVerticalSpacer()
-                BodyRegularLabel(
-                    text = alertMessage,
-                    color = GovUkTheme.colourScheme.textAndIcons.secondary
-                )
-            }
+            BodyRegularLabel(
+                text = alertMessage,
+                color = GovUkTheme.colourScheme.textAndIcons.secondary
+            )
         },
         confirmButton = {
             val continueButton = stringResource(id = R.string.continue_button)
-            TextButton(
+            DialogButton(
+                text = continueButton,
                 onClick = {
                     onContinueButtonClick(continueButton)
                     openDeviceNotificationsSettings(context)
                     onDismiss()
-                }
-            ) {
-                BodyBoldLabel(
-                    text = continueButton,
-                    color = GovUkTheme.colourScheme.textAndIcons.linkSecondary
-                )
-            }
+                },
+                isBold = true,
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.linkSecondary
+            )
         },
         dismissButton = {
             val cancelButton = stringResource(id = R.string.cancel_button)
-            TextButton(
+            DialogButton(
+                text = cancelButton,
                 onClick = {
                     onCancelButtonClick(cancelButton)
                     onDismiss()
-                }
-            ) {
-                BodyRegularLabel(
-                    text = cancelButton,
-                    color = GovUkTheme.colourScheme.textAndIcons.linkSecondary
-                )
-            }
+                },
+                defaultTextColour = GovUkTheme.colourScheme.textAndIcons.linkSecondary
+            )
         },
         containerColor = GovUkTheme.colourScheme.surfaces.alert
     )

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/Alerts.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/Alerts.kt
@@ -40,6 +40,7 @@ internal fun NotificationsSettingsAlert(
                 R.string.notifications_alert_message_on
         )
 
+    // TODO GOVUKAPP-3964 use DialogButton
     AlertDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),


### PR DESCRIPTION
# Title

Added focus indicator for dialog buttons. Our alert dialogs are not 'componentised', to add the custom focus indicator I created a `DialogButton` component and changed the AlertDialog occurrences to use them.

## JIRA ticket(s)
  - [GOVUKAPP-3962](https://govukverify.atlassian.net/browse/GOVUKAPP-3962)

## Figma
 - [Figma board](https://www.figma.com/design/x5i4a5RT0xMhJAcjoIxefb/2025-06-GOV.UK-app-library-v2--UX-refresh?node-id=14123-5629&t=pkxbBXO7OBvdE7wB-1)


## Screen shots
[Screen_recording_20260902_164830.webm](https://github.com/user-attachments/assets/2b7398c0-e26f-4e11-aa2e-60a3445b7e7c)

[Screen_recording_20260902_171301.webm](https://github.com/user-attachments/assets/a3686f92-30fe-45e0-a8cf-b1ae33bb65da)

[Screen_recording_20260902_171833.webm](https://github.com/user-attachments/assets/11226c0e-9375-4f1c-a1e2-0e154401e66c)

[Screen_recording_20260903_125837.webm](https://github.com/user-attachments/assets/cce64f41-4ec2-4684-9e5d-1ce0f4066b7f)

[Screen_recording_20260903_135932.webm](https://github.com/user-attachments/assets/86de0000-cbdb-4e08-9ff9-11654c42f433)

[Screen_recording_20260903_145611.webm](https://github.com/user-attachments/assets/7e558d9d-9538-4440-89ee-69636ab09f84)

[Screen_recording_20260903_152026.webm](https://github.com/user-attachments/assets/8a061744-1b41-4935-a88c-5c904aa409ef)
