### PR TITLE
feat: NOT-373 Country list screen with loading, error, and loaded states

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -99,7 +99,9 @@ import uk.gov.govuk.topics.navigation.topicSelectionGraph
 import uk.gov.govuk.topics.navigation.topicsGraph
 import uk.gov.govuk.topics.ui.model.isDrivingTopic
 import uk.gov.govuk.topics.ui.model.isTravelTopic
-import uk.gov.govuk.travelalerts.ui.TravelAlertsWidget
+import uk.gov.govuk.travelalerts.navigation.COUNTRY_LIST_ROUTE
+import uk.gov.govuk.travelalerts.navigation.travelAlertsGraph
+import uk.gov.govuk.travelalerts.ui.widget.TravelAlertsWidget
 import uk.gov.govuk.visited.navigation.visitedGraph
 import uk.gov.govuk.widgets.ui.contains
 import uk.gov.govuk.widgets.ui.homeWidgets
@@ -603,9 +605,12 @@ private fun GovUkNavHost(
                                 .padding(horizontal = GovUkTheme.spacing.medium),
                             verticalArrangement = Arrangement.spacedBy(GovUkTheme.spacing.medium)
                         ) {
-                            TravelAlertsWidget { url ->
-                                externalLauncher.launch(url) { showBrowserNotFoundAlert = true }
-                            }
+                            TravelAlertsWidget(
+                                launchBrowser = { url ->
+                                    externalLauncher.launch(url) { showBrowserNotFoundAlert = true }
+                                },
+                                onFollowCountry = { navController.navigate(COUNTRY_LIST_ROUTE) }
+                            )
                         }
                     }
                 },
@@ -695,6 +700,11 @@ private fun GovUkNavHost(
                 bottom = imeBottomPadding,
                 end = paddingValues.calculateEndPadding(layoutDirection)
             )
+        )
+        travelAlertsGraph(
+            navController = navController,
+            launchBrowser = { url -> browserLauncher.launch(url) { showBrowserNotFoundAlert = true } },
+            modifier = Modifier.padding(paddingValues)
         )
     }
 

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -142,7 +142,7 @@ fun InternalLinkListItem(
                         )
                     }
                 }
-
+                InternalLinkListItemStyle.Simple -> { /* No icon, else branch kept for compatibility */ }
                 else -> {
                     Icon(
                         painter = painterResource(R.drawable.ic_arrow),
@@ -766,6 +766,16 @@ private fun InternalLinkListItemButtonPreview() {
         InternalLinkListItem(
             AccessibleString("Title"),
             style = InternalLinkListItemStyle.Button(R.drawable.ic_cancel_round, "Alt text") {})
+    }
+}
+
+@Preview
+@Composable
+private fun InternalLinkListItemSimplePreview() {
+    GovUkTheme {
+        InternalLinkListItem(
+            AccessibleString("Title"),
+            style = InternalLinkListItemStyle.Simple)
     }
 }
 

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/model/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/model/List.kt
@@ -15,6 +15,7 @@ sealed interface ExternalLinkListItemStyle {
 
 sealed interface InternalLinkListItemStyle {
     data object Default : InternalLinkListItemStyle
+    data object Simple: InternalLinkListItemStyle
     data class Status(
         val status: String
     ) : InternalLinkListItemStyle

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
@@ -21,6 +21,7 @@ private val BlueDarker25 = Color(0xFF16548A)
 private val BlueDarker50 = Color(0xFF0F385C)
 private val BlueDarker65 = Color(0xFF0A2740)
 private val BlueDarker80 = Color(0xFF061625)
+private val BlueDarker90 = Color(0xFF030B12)
 private val BlueDarker80Alpha50 = Color(0x80061625)
 private val BlueDarkMode = Color(0xFF263D54)
 private val TealPrimary = Color(0xFF158187)
@@ -201,7 +202,8 @@ data class GovUkColourScheme(
         val msgRead: Color,
         val msgUnread: Color,
         val cardMsgHeader: Color,
-        val fullScreen: Color
+        val fullScreen: Color,
+        val surfaceModal: Color
     )
 
     data class Strokes(
@@ -368,7 +370,8 @@ internal val LightColorScheme = GovUkColourScheme(
         msgRead = BlackLighter80,
         msgUnread = RedAccent,
         cardMsgHeader = BlackLighter95,
-        fullScreen = White
+        fullScreen = White,
+        surfaceModal = White
     ),
     strokes = Strokes(
         fixedContainer = BlackAlpha30,
@@ -534,7 +537,8 @@ internal val DarkColorScheme = GovUkColourScheme(
         msgRead = BlackLighter25,
         msgUnread = RedAccent,
         cardMsgHeader = BlueDarker65,
-        fullScreen = BlueDarker80
+        fullScreen = BlueDarker80,
+        surfaceModal = BlueDarker90
     ),
     strokes = Strokes(
         fixedContainer = WhiteAlpha30,
@@ -695,7 +699,8 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             msgRead = Color.Unspecified,
             msgUnread = Color.Unspecified,
             cardMsgHeader = Color.Unspecified,
-            fullScreen = Color.Unspecified
+            fullScreen = Color.Unspecified,
+            surfaceModal = Color.Unspecified
         ),
         strokes = Strokes(
             fixedContainer = Color.Unspecified,

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoImpl.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoImpl.kt
@@ -6,11 +6,11 @@ import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.data.model.Result.Success
 import uk.gov.govuk.data.remote.safeAuthApiCall
 import uk.gov.govuk.travelalerts.data.model.Country
-import uk.gov.govuk.travelalerts.data.remote.TravelAlertsApi
+import uk.gov.govuk.travelalerts.data.remote.GroupsApi
 import uk.gov.govuk.travelalerts.data.model.Group
+import uk.gov.govuk.travelalerts.data.remote.TravelApi
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.time.temporal.TemporalUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,7 +21,8 @@ class DateProviderImpl: DateProvider {
 
 @Singleton
 internal class TravelAlertsRepoImpl @Inject constructor(
-    private val travelAlertsApi: TravelAlertsApi,
+    private val groupsApi: GroupsApi,
+    private val travelApi: TravelApi,
     private val authRepo: AuthRepo,
     private val dateProvider: DateProvider
 ) : TravelAlertsRepo {
@@ -42,7 +43,7 @@ internal class TravelAlertsRepoImpl @Inject constructor(
         }
 
         val res = safeAuthApiCall(apiCall = {
-            travelAlertsApi.getGroups()
+            groupsApi.getGroups()
         }, authRepo = authRepo)
 
         if (res is Success) {
@@ -63,9 +64,9 @@ internal class TravelAlertsRepoImpl @Inject constructor(
         val res = safeAuthApiCall(apiCall = {
             Response.success(
                 listOf(
-                    Country("France", "france", Instant.now().toString()),
-                    Country("Spain", "spain", Instant.now().minus(1, ChronoUnit.DAYS).toString()),
-                    Country("Germany", "germany", Instant.now().minus(7, ChronoUnit.DAYS).toString())
+                    Country("France", "france", Instant.now().toString(), synonyms = listOf()),
+                    Country("Spain", "spain", Instant.now().minus(1, ChronoUnit.DAYS).toString(), listOf()),
+                    Country("Germany", "germany", Instant.now().minus(7, ChronoUnit.DAYS).toString(), listOf())
                 )
             )
         }, authRepo = authRepo)

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/di/TravelAlertsModule.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/di/TravelAlertsModule.kt
@@ -8,10 +8,11 @@ import retrofit2.Retrofit
 import uk.gov.govuk.travelalerts.data.DateProvider
 import uk.gov.govuk.travelalerts.data.DateProviderImpl
 import uk.gov.govuk.travelalerts.data.TravelAlertsRepoImpl
-import uk.gov.govuk.travelalerts.data.remote.TravelAlertsApi
+import uk.gov.govuk.travelalerts.data.remote.GroupsApi
 import uk.gov.govuk.travelalerts.DefaultTravelAlertsFeature
 import uk.gov.govuk.travelalerts.TravelAlertsFeature
 import uk.gov.govuk.travelalerts.data.TravelAlertsRepo
+import uk.gov.govuk.travelalerts.data.remote.TravelApi
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -20,8 +21,13 @@ import javax.inject.Singleton
 internal object TravelAlertsModule {
     @Provides
     @Singleton
-    fun providesTravelAlertsApi(@Named("FlexRetrofit") retrofit: Retrofit): TravelAlertsApi =
-        retrofit.create(TravelAlertsApi::class.java)
+    fun providesGroupsApi(@Named("FlexRetrofit") retrofit: Retrofit): GroupsApi =
+        retrofit.create(GroupsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun providesTravelApi(@Named("FlexRetrofit") retrofit: Retrofit): TravelApi =
+        retrofit.create(TravelApi::class.java)
 
     @Provides
     @Singleton

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/model/Country.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/model/Country.kt
@@ -4,12 +4,11 @@ import com.google.gson.annotations.SerializedName
 import java.time.Instant
 
 data class Country(
-    @SerializedName("Name")
     val name: String,
-    @SerializedName("Slug")
     val slug: String,
-    @SerializedName("LastUpdated")
-    val rawLastUpdated: String
+    @SerializedName("lastUpdate")
+    val rawLastUpdated: String,
+    val synonyms: List<String>
 ) {
     val date: Instant
         get() = Instant.parse(rawLastUpdated)

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/remote/GroupsApi.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/remote/GroupsApi.kt
@@ -5,7 +5,7 @@ import retrofit2.http.GET
 import uk.gov.govuk.travelalerts.data.model.Group
 
 
-interface TravelAlertsApi {
+interface GroupsApi {
     companion object {
         private const val GROUPS_PATH = "/app/groups/v1/groups"
     }

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/remote/TravelApi.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/data/remote/TravelApi.kt
@@ -1,0 +1,15 @@
+package uk.gov.govuk.travelalerts.data.remote
+
+import retrofit2.Response
+import retrofit2.http.GET
+import uk.gov.govuk.travelalerts.data.model.Country
+import uk.gov.govuk.travelalerts.data.model.Group
+
+
+interface TravelApi {
+    companion object {
+        private const val COUNTRIES_PATH = "/app/travel/v1/countries"
+    }
+    @GET(COUNTRIES_PATH)
+    suspend fun getCountries(): Response<List<Country>>
+}

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/navigation/TravelAlertsNavigation.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/navigation/TravelAlertsNavigation.kt
@@ -1,14 +1,28 @@
 package uk.gov.govuk.travelalerts.navigation
 
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import uk.gov.govuk.travelalerts.ui.countrylist.CountryListScreen
 
+const val COUNTRY_LIST_ROUTE = "country_list_route"
 
 fun NavGraphBuilder.travelAlertsGraph(
     navController: NavController,
     launchBrowser: (url: String) -> Unit,
     modifier: Modifier
 ) {
-    // Nothing here yet
+    composable(
+        route = COUNTRY_LIST_ROUTE,
+        enterTransition = { slideInVertically { it } },
+        popExitTransition = { slideOutVertically { it } }
+    ) {
+        CountryListScreen(
+            onClose = { navController.popBackStack() },
+            modifier = modifier
+        )
+    }
 }

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/countrylist/CountryListScreen.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/countrylist/CountryListScreen.kt
@@ -1,0 +1,218 @@
+package uk.gov.govuk.travelalerts.ui.countrylist
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.gov.govuk.design.ui.component.BodyRegularLabel
+import uk.gov.govuk.design.ui.component.FixedPrimaryButton
+import uk.gov.govuk.design.ui.component.InternalLinkListItem
+import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
+import uk.gov.govuk.design.ui.component.LoadingScreen
+import uk.gov.govuk.design.ui.component.MediumHorizontalSpacer
+import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.SmallHorizontalSpacer
+import uk.gov.govuk.design.ui.component.Title2BoldLabel
+import uk.gov.govuk.design.ui.component.error.ErrorPage
+import uk.gov.govuk.design.ui.model.AccessibleString
+import uk.gov.govuk.design.ui.model.InternalLinkListItemStyle
+import uk.gov.govuk.design.ui.theme.GovUkTheme
+import uk.gov.govuk.travelalerts.R
+import uk.gov.govuk.travelalerts.data.model.Country
+
+@Composable
+fun CountryListScreen(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CountryListViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.onPageView()
+    }
+
+    Column(modifier.fillMaxSize()) {
+        CountryListHeader(onClose = onClose)
+
+        when (val state = uiState) {
+            is CountryListViewModel.State.Loading -> LoadingScreen()
+            is CountryListViewModel.State.Error -> CountryListError(onRetry = viewModel::onPageView)
+            is CountryListViewModel.State.Loaded -> CountryListLoaded(countries = state.countries)
+        }
+    }
+}
+
+@Composable
+private fun CountryListHeader(onClose: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(64.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Title2BoldLabel(
+            text = stringResource(R.string.follow_a_country_title),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 56.dp)
+                .semantics { heading() },
+            textAlign = TextAlign.Center
+        )
+        TextButton(
+            onClick = onClose,
+            modifier = Modifier.align(Alignment.CenterStart)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = stringResource(uk.gov.govuk.design.R.string.content_desc_close),
+                tint = GovUkTheme.colourScheme.textAndIcons.linkSecondary
+            )
+        }
+    }
+}
+
+@Composable
+private fun CountryListLoaded(
+    countries: List<Country>,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier
+            .fillMaxSize()
+            .background(GovUkTheme.colourScheme.surfaces.surfaceModal)
+    ) {
+        CountrySearchBar(
+            modifier = Modifier.padding(
+                horizontal = GovUkTheme.spacing.medium,
+                vertical = GovUkTheme.spacing.small
+            )
+        )
+        LazyColumn(Modifier.padding(horizontal = GovUkTheme.spacing.medium)) {
+            item { MediumVerticalSpacer() }
+            itemsIndexed(countries) { index, country ->
+                InternalLinkListItem(
+                    title = AccessibleString(country.name),
+                    onClick = {},
+                    isFirst = index == 0,
+                    isLast = index == countries.lastIndex,
+                    style = InternalLinkListItemStyle.Simple,
+                    background = GovUkTheme.colourScheme.surfaces.listAlt
+                )
+            }
+            item { LargeVerticalSpacer() }
+        }
+    }
+}
+
+@Composable
+private fun CountrySearchBar(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .clip(RoundedCornerShape(28.dp))
+            .background(GovUkTheme.colourScheme.surfaces.textFieldBackground),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        MediumHorizontalSpacer()
+        Icon(
+            imageVector = Icons.Filled.Search,
+            contentDescription = null,
+            tint = GovUkTheme.colourScheme.textAndIcons.secondary
+        )
+        SmallHorizontalSpacer()
+        BodyRegularLabel(
+            text = stringResource(R.string.country_list_search_placeholder),
+            color = GovUkTheme.colourScheme.textAndIcons.secondary
+        )
+    }
+}
+
+@Composable
+private fun CountryListError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ErrorPage(
+        headerText = stringResource(R.string.error_title),
+        subText = listOf(stringResource(R.string.error_description)),
+        modifier = modifier,
+        footerContent = {
+            FixedPrimaryButton(
+                text = stringResource(R.string.error_retry),
+                onClick = onRetry
+            )
+        }
+    )
+}
+
+@Composable
+@PreviewLightDark
+private fun CountryListLoadingPreview() {
+    GovUkTheme {
+        Column(Modifier.fillMaxSize()) {
+            CountryListHeader(onClose = {})
+            LoadingScreen()
+        }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun CountryListErrorPreview() {
+    GovUkTheme {
+        Column(Modifier.fillMaxSize()) {
+            CountryListHeader(onClose = {})
+            CountryListError(onRetry = {})
+        }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun CountryListLoadedPreview() {
+    val countries = listOf(
+        Country("Afghanistan", "afghanistan", "2022-01-01T00:00:00Z", listOf()),
+        Country("Albania", "albania", "2023-01-01T00:00:00Z", listOf()),
+        Country("Algeria", "algeria", "2024-01-01T00:00:00Z", listOf()),
+        Country("Andorra", "andorra", "2025-01-01T00:00:00Z", listOf()),
+        Country("Anguilla", "anguilla", "2026-01-01T00:00:00Z", listOf()),
+    )
+    GovUkTheme {
+        Column(
+            Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Top
+        ) {
+            CountryListHeader(onClose = {})
+            CountryListLoaded(countries = countries)
+        }
+    }
+}

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/countrylist/CountryListViewModel.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/countrylist/CountryListViewModel.kt
@@ -1,0 +1,57 @@
+package uk.gov.govuk.travelalerts.ui.countrylist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import uk.gov.govuk.analytics.AnalyticsClient
+import uk.gov.govuk.data.model.Result
+import uk.gov.govuk.travelalerts.data.TravelAlertsRepo
+import uk.gov.govuk.travelalerts.data.model.Country
+import javax.inject.Inject
+
+@HiltViewModel
+class CountryListViewModel @Inject constructor(
+    private val travelAlertsRepo: TravelAlertsRepo,
+    private val analyticsClient: AnalyticsClient
+) : ViewModel() {
+
+    companion object {
+        private const val SCREEN_CLASS = "CountryListScreen"
+        private const val SCREEN_NAME = "Follow a country"
+        private const val TITLE = "Follow a country"
+    }
+
+    sealed class State {
+        data object Loading : State()
+        data class Loaded(val countries: List<Country>) : State()
+        data object Error : State()
+    }
+
+    private val _uiState: MutableStateFlow<State> = MutableStateFlow(State.Loading)
+    val uiState = _uiState.asStateFlow()
+
+    fun onPageView() {
+        analyticsClient.screenView(
+            screenClass = SCREEN_CLASS,
+            screenName = SCREEN_NAME,
+            title = TITLE
+        )
+        viewModelScope.launch {
+            _uiState.value = State.Loading
+            when (val result = travelAlertsRepo.getCountries()) {
+                is Result.Success -> {
+                    if (result.value.isEmpty()) {
+                        _uiState.value = State.Error
+                    } else {
+                        val sorted = result.value.sortedBy { it.name }
+                        _uiState.value = State.Loaded(sorted)
+                    }
+                }
+                else -> _uiState.value = State.Error
+            }
+        }
+    }
+}

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/widget/TravelAlertsWidget.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/widget/TravelAlertsWidget.kt
@@ -1,4 +1,4 @@
-package uk.gov.govuk.travelalerts.ui
+package uk.gov.govuk.travelalerts.ui.widget
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -37,13 +37,16 @@ import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.travelalerts.R
 
 @Composable
-fun TravelAlertsWidget (launchBrowser: (String) -> Unit) {
+fun TravelAlertsWidget(
+    launchBrowser: (String) -> Unit,
+    onFollowCountry: () -> Unit
+) {
     val viewModel: TravelAlertsWidgetViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     when (val state = uiState) {
         TravelAlertsWidgetViewModel.State.Loading -> TravelAlertsLoading()
-        TravelAlertsWidgetViewModel.State.Empty -> TravelAlertsEmpty()
+        TravelAlertsWidgetViewModel.State.Empty -> TravelAlertsEmpty(onFollowCountry)
         is TravelAlertsWidgetViewModel.State.Loaded -> TravelAlertsLoaded(state.rows) { row ->
             viewModel.onRowClick(row)
             launchBrowser(row.link)
@@ -65,9 +68,9 @@ private fun TravelAlertsLoading() {
 }
 
 @Composable
-private fun TravelAlertsEmpty() {
+private fun TravelAlertsEmpty(onFollowCountry: () -> Unit) {
     CentredCardWithIcon(
-        onClick = { },
+        onClick = onFollowCountry,
         icon = uk.gov.govuk.design.R.drawable.ic_add,
         title = stringResource(R.string.empty_title),
         description = stringResource(R.string.empty_description),
@@ -132,13 +135,13 @@ private fun TravelAlertsError() {
             MediumVerticalSpacer()
 
             BodyBoldLabel(
-                text = "Title",
+                text = stringResource(R.string.error_title),
                 textAlign = TextAlign.Center
             )
 
             ExtraSmallVerticalSpacer()
 
-            BodyRegularLabel("Body")
+            BodyRegularLabel(stringResource(R.string.error_description))
 
             ExtraLargeVerticalSpacer()
         }
@@ -157,7 +160,7 @@ private fun TravelAlertsLoadingPreview() {
 @PreviewLightDark
 fun TravelAlertsWidgetEmptyPreview() {
     GovUkTheme {
-        TravelAlertsEmpty()
+        TravelAlertsEmpty(onFollowCountry = {})
     }
 }
 

--- a/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/widget/TravelAlertsWidgetViewModel.kt
+++ b/feature/travelalerts/src/main/kotlin/uk/gov/govuk/travelalerts/ui/widget/TravelAlertsWidgetViewModel.kt
@@ -1,4 +1,4 @@
-package uk.gov.govuk.travelalerts.ui
+package uk.gov.govuk.travelalerts.ui.widget
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/feature/travelalerts/src/main/res/values/strings.xml
+++ b/feature/travelalerts/src/main/res/values/strings.xml
@@ -4,4 +4,9 @@
     <string name="empty_description">Get messages and notifications when travel advice changes</string>
     <string name="loaded_heading">Countries you follow</string>
     <string name="loaded_button_edit">Edit</string>
+    <string name="follow_a_country_title">Follow a country</string>
+    <string name="country_list_search_placeholder">Search</string>
+    <string name="error_title">There\'s a problem</string>
+    <string name="error_description">We could not load travel alerts. Try again later.</string>
+    <string name="error_retry">Try again</string>
 </resources>

--- a/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoTest.kt
+++ b/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/data/TravelAlertsRepoTest.kt
@@ -12,7 +12,8 @@ import retrofit2.Response
 import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.travelalerts.data.model.Group
-import uk.gov.govuk.travelalerts.data.remote.TravelAlertsApi
+import uk.gov.govuk.travelalerts.data.remote.GroupsApi
+import uk.gov.govuk.travelalerts.data.remote.TravelApi
 import uk.gov.govuk.travelalerts.fixtures.TravelAlertsFixtures
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -21,7 +22,8 @@ import kotlin.test.assertTrue
 
 class TravelAlertsRepoTest {
 
-    private val api = mockk<TravelAlertsApi>(relaxed = true)
+    private val api = mockk<GroupsApi>(relaxed = true)
+    private val travelApi = mockk<TravelApi>(relaxed = true)
     private val auth = mockk<AuthRepo>(relaxed = true)
     private var mockDateProvider = mockk<DateProvider>()
 
@@ -33,7 +35,7 @@ class TravelAlertsRepoTest {
     @Before
     fun setup() {
         every { mockDateProvider.date } returns Instant.now()
-        travelAlertsRepo = TravelAlertsRepoImpl(api, auth, mockDateProvider)
+        travelAlertsRepo = TravelAlertsRepoImpl(api, travelApi, auth, mockDateProvider)
     }
 
     // Get Groups

--- a/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/fixtures/TravelAlertsFixtures.kt
+++ b/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/fixtures/TravelAlertsFixtures.kt
@@ -5,14 +5,14 @@ import uk.gov.govuk.travelalerts.data.model.Group
 
 object TravelAlertsFixtures {
     val mockGroups = listOf(
-        Group(namespace = "ns1", group = "france", subgroup = "region1"),
-        Group(namespace = "ns2", group = "germany", subgroup = "region2"),
-        Group(namespace = "ns3", group = "spain", subgroup = "region3")
+        Group(namespace = "travel", group = "france", subgroup = "daily"),
+        Group(namespace = "travel", group = "germany", subgroup = "daily"),
+        Group(namespace = "travel", group = "spain", subgroup = "daily")
     )
 
     val mockCountries = listOf(
-        Country(name = "France", slug = "france", rawLastUpdated = "2024-01-01T00:00:00Z"),
-        Country(name = "Germany", slug = "germany", rawLastUpdated = "2024-01-01T00:00:00Z"),
-        Country(name = "Spain", slug = "spain", rawLastUpdated = "2024-01-01T00:00:00Z")
+        Country(name = "France", slug = "france", rawLastUpdated = "2024-01-01T00:00:00Z", synonyms = emptyList()),
+        Country(name = "Germany", slug = "germany", rawLastUpdated = "2025-01-01T00:00:00Z", synonyms = emptyList()),
+        Country(name = "Spain", slug = "spain", rawLastUpdated = "2024-06-01T00:00:00Z", synonyms = emptyList())
     )
 }

--- a/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/ui/countrylist/CountryListViewModelTest.kt
+++ b/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/ui/countrylist/CountryListViewModelTest.kt
@@ -1,0 +1,127 @@
+package uk.gov.govuk.travelalerts.ui.countrylist
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import uk.gov.govuk.analytics.AnalyticsClient
+import uk.gov.govuk.data.model.Result
+import uk.gov.govuk.travelalerts.data.TravelAlertsRepo
+import uk.gov.govuk.travelalerts.data.model.Country
+import uk.gov.govuk.travelalerts.fixtures.TravelAlertsFixtures
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CountryListViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val travelAlertsRepo = mockk<TravelAlertsRepo>(relaxed = true)
+    private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
+    private lateinit var viewModel: CountryListViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        viewModel = CountryListViewModel(travelAlertsRepo, analyticsClient)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `Given view created, then state is Loading`() {
+        assertTrue(viewModel.uiState.value is CountryListViewModel.State.Loading)
+    }
+
+    @Test
+    fun `Given page view, when countries load successfully, then state is Loaded`() = runTest {
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
+
+        viewModel.onPageView()
+
+        val state = viewModel.uiState.value as CountryListViewModel.State.Loaded
+        assertEquals(TravelAlertsFixtures.mockCountries.size, state.countries.size)
+    }
+
+    @Test
+    fun `Given page view, when countries load successfully, then countries are sorted alphabetically`() = runTest {
+        val unsorted = TravelAlertsFixtures.mockCountries.reversed() // Alphabetical in the fixture
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(unsorted)
+
+        viewModel.onPageView()
+
+        val state = viewModel.uiState.value as CountryListViewModel.State.Loaded
+        assertEquals(listOf("France", "Germany", "Spain"), state.countries.map { it.name })
+    }
+
+    @Test
+    fun `Given page view, when countries list is empty, then state is Error`() = runTest {
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(emptyList())
+
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is CountryListViewModel.State.Error)
+    }
+
+    @Test
+    fun `Given page view, when service not responding, then state is Error`() = runTest {
+        coEvery { travelAlertsRepo.getCountries() } returns Result.ServiceNotResponding(500)
+
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is CountryListViewModel.State.Error)
+    }
+
+    @Test
+    fun `Given page view, when device offline, then state is Error`() = runTest {
+        coEvery { travelAlertsRepo.getCountries() } returns Result.DeviceOffline()
+
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is CountryListViewModel.State.Error)
+    }
+
+    @Test
+    fun `Given page view, then state transitions through Loading before resolving`() = runTest {
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
+
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is CountryListViewModel.State.Loaded)
+    }
+
+    @Test
+    fun `Given successful page view, when page viewed again, then state reloads`() = runTest {
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Success(TravelAlertsFixtures.mockCountries)
+        viewModel.onPageView()
+        assertTrue(viewModel.uiState.value is CountryListViewModel.State.Loaded)
+
+        coEvery { travelAlertsRepo.getCountries() } returns Result.Error()
+        viewModel.onPageView()
+
+        assertTrue(viewModel.uiState.value is CountryListViewModel.State.Error)
+    }
+
+    @Test
+    fun `Given page view, then screen view analytics event is fired`() = runTest {
+        viewModel.onPageView()
+
+        verify {
+            analyticsClient.screenView(
+                screenClass = "CountryListScreen",
+                screenName = "Follow a country",
+                title = "Follow a country"
+            )
+        }
+    }
+}

--- a/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/ui/widget/TravelAlertsWidgetViewModelTest.kt
+++ b/feature/travelalerts/src/test/kotlin/uk/gov/govuk/travelalerts/ui/widget/TravelAlertsWidgetViewModelTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.govuk.travelalerts.ui
+package uk.gov.govuk.travelalerts.ui.widget
 
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -17,8 +17,6 @@ import org.junit.Test
 import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.travelalerts.data.TravelAlertsRepo
-import uk.gov.govuk.travelalerts.data.model.Country
-import uk.gov.govuk.travelalerts.data.model.Group
 import uk.gov.govuk.travelalerts.fixtures.TravelAlertsFixtures
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -59,16 +57,10 @@ class TravelAlertsWidgetViewModelTest {
 
     @Test
     fun `Given page view, when both repos succeed, then rows are sorted by country name`() = runTest {
-        val unsortedGroups = listOf(
-            Group(namespace = "ns1", group = "spain", subgroup = "daily"),
-            Group(namespace = "ns2", group = "france", subgroup = "daily"),
-            Group(namespace = "ns3", group = "germany", subgroup = "daily"),
-        )
-        val unsortedCountries = listOf(
-            Country(name = "Spain", slug = "spain", rawLastUpdated = "2024-01-01T00:00:00Z"),
-            Country(name = "France", slug = "france", rawLastUpdated = "2024-01-01T00:00:00Z"),
-            Country(name = "Germany", slug = "germany", rawLastUpdated = "2024-01-01T00:00:00Z"),
-        )
+        // Both are alphabetical in the fixture
+        val unsortedGroups = TravelAlertsFixtures.mockGroups.reversed()
+        val unsortedCountries = TravelAlertsFixtures.mockCountries.reversed()
+
         coEvery { travelAlertsRepo.getGroups() } returns Result.Success(unsortedGroups)
         coEvery { travelAlertsRepo.getCountries() } returns Result.Success(unsortedCountries)
 


### PR DESCRIPTION
# Country selection screen for Travel Alerts

Does not currently navigate anywhere, and the country list itself is mocked while the endpoint is finished

## JIRA ticket(s)
  - [NOT-473](https://gdsgovukagents.atlassian.net/browse/NOT-373)

## Figma
  - [Figma board](https://www.figma.com/design/TJKGPyTt8RnvVTqK9KFijt/Travel-Advice?node-id=3491-18465&m=dev)

## Screen shots

<img width="1080" height="2400" alt="Screenshot_20260904_145028" src="https://github.com/user-attachments/assets/0ac89135-af68-49b1-ab66-be86ba4418be" />
<img width="1080" height="2400" alt="Screenshot_20260904_145041" src="https://github.com/user-attachments/assets/b057d1df-1003-4f3b-a757-76775b360cf2" />


[NOT-473]: https://gdsgovukagents.atlassian.net/browse/NOT-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ