### PR TITLE
GOVUKAPP-3984 Focus indicator missing for some components

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
@@ -142,31 +142,10 @@ private fun Header(
                     is HeaderActionStyle.TextActionButton -> {
                         Spacer(Modifier.weight(1f))
 
-                        val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
-                        val isFocused by interactionSource.collectIsFocusedAsState()
-
-                        val textColour = if (isFocused) {
-                            GovUkTheme.colourScheme.textAndIcons.focused
-                        } else {
-                            actionColour
-                        }
-
-                        TextButton(
-                            onClick = actionStyle.onClick,
-                            interactionSource = interactionSource,
-                            colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
-                                containerColor = if (isFocused) GovUkTheme.colourScheme.surfaces.focused else Color.Transparent
-                            )
-                        ) {
-                            BodyRegularLabel(
-                                text = actionStyle.title,
-                                color = textColour,
-                                textAlign = TextAlign.End,
-                                modifier = Modifier.semantics {
-                                    contentDescription = actionStyle.altText ?: actionStyle.title
-                                }
-                            )
-                        }
+                        HeaderTextButton(
+                            actionStyle = actionStyle,
+                            actionColour = actionColour
+                        )
                     }
                     is HeaderActionStyle.OverflowActionButton -> {
                         Spacer(Modifier.weight(1f))
@@ -193,6 +172,38 @@ private fun Header(
                 color = titleColour
             )
         }
+    }
+}
+
+@Composable
+private fun HeaderTextButton(
+    actionStyle: HeaderActionStyle.TextActionButton,
+    actionColour: Color
+) {
+    val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val textColour = if (isFocused) {
+        GovUkTheme.colourScheme.textAndIcons.focused
+    } else {
+        actionColour
+    }
+
+    TextButton(
+        onClick = actionStyle.onClick,
+        interactionSource = interactionSource,
+        colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+            containerColor = if (isFocused) GovUkTheme.colourScheme.surfaces.focused else Color.Transparent
+        )
+    ) {
+        BodyRegularLabel(
+            text = actionStyle.title,
+            color = textColour,
+            textAlign = TextAlign.End,
+            modifier = Modifier.semantics {
+                contentDescription = actionStyle.altText ?: actionStyle.title
+            }
+        )
     }
 }
 

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
@@ -1,7 +1,7 @@
 package uk.gov.govuk.design.ui.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -140,12 +142,25 @@ private fun Header(
                     is HeaderActionStyle.TextActionButton -> {
                         Spacer(Modifier.weight(1f))
 
+                        val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
+                        val isFocused by interactionSource.collectIsFocusedAsState()
+
+                        val textColour = if (isFocused) {
+                            GovUkTheme.colourScheme.textAndIcons.focused
+                        } else {
+                            actionColour
+                        }
+
                         TextButton(
-                            onClick = actionStyle.onClick
+                            onClick = actionStyle.onClick,
+                            interactionSource = interactionSource,
+                            colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                containerColor = if (isFocused) GovUkTheme.colourScheme.surfaces.focused else Color.Transparent
+                            )
                         ) {
                             BodyRegularLabel(
                                 text = actionStyle.title,
-                                color = actionColour,
+                                color = textColour,
                                 textAlign = TextAlign.End,
                                 modifier = Modifier.semantics {
                                     contentDescription = actionStyle.altText ?: actionStyle.title
@@ -174,7 +189,6 @@ private fun Header(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = GovUkTheme.spacing.medium)
-                    .focusable()
                     .semantics { heading() },
                 color = titleColour
             )

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -54,6 +54,33 @@ import uk.gov.govuk.design.ui.model.ListItemColours
 import uk.gov.govuk.design.ui.model.StatusListItemIconStyle
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 
+@Composable
+private fun LinkListItemTrailingButton(
+    @DrawableRes icon: Int,
+    altText: String,
+    onClick: () -> Unit,
+    defaultIconTint: Color,
+    modifier: Modifier = Modifier
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val (containerColor, iconColor) = if (isFocused) {
+        GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+    } else {
+        Color.Transparent to defaultIconTint
+    }
+
+    TextButton(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        modifier = modifier.semantics { contentDescription = altText },
+        colors = textButtonColors(containerColor = containerColor),
+        contentPadding = PaddingValues(start = GovUkTheme.spacing.extraLarge)
+    ) {
+        Icon(painter = painterResource(icon), contentDescription = null, tint = iconColor)
+    }
+}
 
 @Composable
 fun InternalLinkListItem(
@@ -129,32 +156,13 @@ fun InternalLinkListItem(
                 }
 
                 is InternalLinkListItemStyle.Button -> {
-                    val buttonInteractionSource = remember { MutableInteractionSource() }
-                    val isButtonFocused by buttonInteractionSource.collectIsFocusedAsState()
-
-                    val (containerColor, iconColor) = if (isButtonFocused) {
-                        GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
-                    } else {
-                        Color.Transparent to colours.contentSecondary
-                    }
-
-                    TextButton(
+                    LinkListItemTrailingButton(
+                        icon = style.icon,
+                        altText = style.altText,
                         onClick = style.onClick,
-                        interactionSource = buttonInteractionSource,
-                        modifier = Modifier
-                            .semantics { contentDescription = style.altText }
-                            .align(Alignment.CenterVertically),
-                        colors = textButtonColors(
-                            containerColor = containerColor
-                        ),
-                        contentPadding = PaddingValues(start = GovUkTheme.spacing.extraLarge)
-                    ) {
-                        Icon(
-                            painter = painterResource(style.icon),
-                            contentDescription = null,
-                            tint = iconColor
-                        )
-                    }
+                        defaultIconTint = colours.contentSecondary,
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    )
                 }
 
                 else -> {
@@ -225,32 +233,13 @@ fun ExternalLinkListItem(
                 }
 
                 is ExternalLinkListItemStyle.Button -> {
-                    val buttonInteractionSource = remember { MutableInteractionSource() }
-                    val isButtonFocused by buttonInteractionSource.collectIsFocusedAsState()
-
-                    val (containerColor, iconColor) = if (isButtonFocused) {
-                        GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
-                    } else {
-                        Color.Transparent to colours.contentSecondary
-                    }
-
-                    TextButton(
+                    LinkListItemTrailingButton(
+                        icon = style.icon,
+                        altText = style.altText,
                         onClick = style.onClick,
-                        interactionSource = buttonInteractionSource,
-                        modifier = Modifier
-                            .semantics { contentDescription = style.altText }
-                            .align(Alignment.CenterVertically),
-                        colors = textButtonColors(
-                            containerColor = containerColor
-                        ),
-                        contentPadding = PaddingValues(start = GovUkTheme.spacing.extraLarge)
-                    ) {
-                        Icon(
-                            painter = painterResource(style.icon),
-                            contentDescription = null,
-                            tint = iconColor
-                        )
-                    }
+                        defaultIconTint = colours.contentSecondary,
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    )
                 }
                 else -> { /* Do nothing */ }
             }
@@ -745,7 +734,6 @@ private fun resolveListItemColours(isFocused: Boolean, isClickable: Boolean): Li
         )
     }
 }
-
 
 @Preview
 @Composable

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -225,18 +225,30 @@ fun ExternalLinkListItem(
                 }
 
                 is ExternalLinkListItemStyle.Button -> {
+                    val buttonInteractionSource = remember { MutableInteractionSource() }
+                    val isButtonFocused by buttonInteractionSource.collectIsFocusedAsState()
+
+                    val (containerColor, iconColor) = if (isButtonFocused) {
+                        GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+                    } else {
+                        Color.Transparent to colours.contentSecondary
+                    }
+
                     TextButton(
                         onClick = style.onClick,
+                        interactionSource = buttonInteractionSource,
                         modifier = Modifier
                             .semantics { contentDescription = style.altText }
-                            .focusable(false)
                             .align(Alignment.CenterVertically),
+                        colors = textButtonColors(
+                            containerColor = containerColor
+                        ),
                         contentPadding = PaddingValues(start = GovUkTheme.spacing.extraLarge)
                     ) {
                         Icon(
                             painter = painterResource(style.icon),
                             contentDescription = null,
-                            tint = colours.contentSecondary
+                            tint = iconColor
                         )
                     }
                 }

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.ButtonDefaults.textButtonColors
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.TextButton
@@ -128,17 +129,30 @@ fun InternalLinkListItem(
                 }
 
                 is InternalLinkListItemStyle.Button -> {
+                    val buttonInteractionSource = remember { MutableInteractionSource() }
+                    val isButtonFocused by buttonInteractionSource.collectIsFocusedAsState()
+
+                    val (containerColor, iconColor) = if (isButtonFocused) {
+                        GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+                    } else {
+                        Color.Transparent to colours.contentSecondary
+                    }
+
                     TextButton(
                         onClick = style.onClick,
+                        interactionSource = buttonInteractionSource,
                         modifier = Modifier
                             .semantics { contentDescription = style.altText }
                             .align(Alignment.CenterVertically),
+                        colors = textButtonColors(
+                            containerColor = containerColor
+                        ),
                         contentPadding = PaddingValues(start = GovUkTheme.spacing.extraLarge)
                     ) {
                         Icon(
                             painter = painterResource(style.icon),
                             contentDescription = null,
-                            tint = colours.contentSecondary
+                            tint = iconColor
                         )
                     }
                 }

--- a/feature/search/src/main/kotlin/uk/gov/govuk/search/ui/PreviousSearches.kt
+++ b/feature/search/src/main/kotlin/uk/gov/govuk/search/ui/PreviousSearches.kt
@@ -1,7 +1,11 @@
 package uk.gov.govuk.search.ui
 
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults.textButtonColors
 import androidx.compose.material3.Icon
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,6 +30,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -131,8 +138,21 @@ private fun Header(
 
         SmallHorizontalSpacer()
 
+        val interactionSource = remember { MutableInteractionSource() }
+        val isFocused by interactionSource.collectIsFocusedAsState()
+
+        val (containerColor, textColor) = if (isFocused) {
+            GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+        } else {
+            Color.Transparent to GovUkTheme.colourScheme.textAndIcons.buttonSecondary
+        }
+
         TextButton(
-            onClick = onRemoveAll
+            onClick = onRemoveAll,
+            interactionSource = interactionSource,
+            colors = textButtonColors(
+                containerColor = containerColor
+            )
         ) {
             BodyRegularLabel(
                 text = stringResource(R.string.remove_all_button),
@@ -140,7 +160,7 @@ private fun Header(
                     .semantics {
                         contentDescription = context.getString(R.string.content_desc_delete_all)
                     },
-                color = GovUkTheme.colourScheme.textAndIcons.buttonSecondary,
+                color = textColor,
             )
         }
     }
@@ -155,12 +175,26 @@ private fun PreviousSearch(
 ) {
     val context = LocalContext.current
 
+    val interactionSource = remember { MutableInteractionSource() }
+    val isRowFocused by interactionSource.collectIsFocusedAsState()
+
+    val (rowBackground, rowContentColour) = if (isRowFocused) {
+        GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+    } else {
+        Color.Transparent to GovUkTheme.colourScheme.textAndIcons.primary
+    }
+
     Column(modifier) {
         ListDivider()
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onClick(searchTerm) }
+                .background(rowBackground)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = LocalIndication.current,
+                    onClick = { onClick(searchTerm) }
+                )
                 .semantics {
                     onClick(label = context.getString(R.string.content_desc_search)) { true }
                 },
@@ -170,22 +204,40 @@ private fun PreviousSearch(
                 imageVector = Icons.Filled.Search,
                 contentDescription = null,
                 modifier = Modifier.size(18.dp),
-                tint = GovUkTheme.colourScheme.textAndIcons.secondary
+                tint = if (isRowFocused) rowContentColour else GovUkTheme.colourScheme.textAndIcons.secondary
             )
             ExtraSmallHorizontalSpacer()
             BodyRegularLabel(
                 text = searchTerm,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                color = rowContentColour
             )
             ExtraSmallHorizontalSpacer()
+
+            var isClearButtonFocused by remember { mutableStateOf(false) }
+
+            val (clearContainerColour, clearIconColor) = if (isClearButtonFocused) {
+                GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+            } else {
+                Color.Transparent to GovUkTheme.colourScheme.textAndIcons.trailingIcon
+            }
+
             TextButton(
-                onClick = { onRemove(searchTerm) }
+                onClick = { onRemove(searchTerm) },
+                modifier = Modifier
+                    .onFocusChanged { state ->
+                        isClearButtonFocused = state.isFocused
+                    },
+                colors = textButtonColors(
+                    containerColor = clearContainerColour,
+                    contentColor = clearIconColor
+                )
             ) {
                 Icon(
                     imageVector = Icons.Filled.Clear,
                     contentDescription = stringResource(R.string.content_desc_remove_from_search_history),
                     modifier = Modifier.size(18.dp),
-                    tint = GovUkTheme.colourScheme.textAndIcons.trailingIcon
+                    tint = clearIconColor
                 )
             }
         }

--- a/feature/search/src/main/kotlin/uk/gov/govuk/search/ui/SearchAutocomplete.kt
+++ b/feature/search/src/main/kotlin/uk/gov/govuk/search/ui/SearchAutocomplete.kt
@@ -1,7 +1,10 @@
 package uk.gov.govuk.search.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
@@ -84,7 +88,8 @@ internal fun SearchAutocomplete(
                         .padding(
                             top = GovUkTheme.spacing.medium,
                             bottom = GovUkTheme.spacing.small
-                        ).semantics {
+                        )
+                        .semantics {
                             liveRegion = LiveRegionMode.Polite
                             contentDescription = searchesAnnouncement
                         },
@@ -100,12 +105,27 @@ internal fun SearchAutocomplete(
                 }
             }
             items(suggestions) { suggestion ->
+
+                val interactionSource = remember { MutableInteractionSource() }
+                val isFocused by interactionSource.collectIsFocusedAsState()
+
+                val (backgroundColor, contentColor) = if (isFocused) {
+                    GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+                } else {
+                    Color.Transparent to GovUkTheme.colourScheme.textAndIcons.primary
+                }
+
                 Column {
                     ListDivider()
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onSearch(suggestion) }
+                            .background(backgroundColor)
+                            .clickable(
+                                interactionSource = interactionSource,
+                                indication = androidx.compose.foundation.LocalIndication.current,
+                                onClick = { onSearch(suggestion) }
+                            )
                             .padding(
                                 top = GovUkTheme.spacing.medium,
                                 bottom = GovUkTheme.spacing.medium
@@ -122,7 +142,7 @@ internal fun SearchAutocomplete(
                             tint = GovUkTheme.colourScheme.textAndIcons.secondary
                         )
                         ExtraSmallHorizontalSpacer()
-                        Text(text = highlightSearchTerms(suggestion, searchTerm))
+                        Text(text = highlightSearchTerms(suggestion, searchTerm, contentColor))
                     }
                 }
             }
@@ -134,7 +154,7 @@ internal fun SearchAutocomplete(
 }
 
 @Composable
-private fun highlightSearchTerms(suggestion: String, searchTerm: String): AnnotatedString {
+private fun highlightSearchTerms(suggestion: String, searchTerm: String, textColor: Color): AnnotatedString {
     val suggestionWords = suggestion.split(" ")
     val searchTermWords = searchTerm.split(" ")
     val marker = '|'
@@ -152,7 +172,7 @@ private fun highlightSearchTerms(suggestion: String, searchTerm: String): Annota
         }
     }
 
-    return highlightVariants(suggestionWords, mappedVariants, marker)
+    return highlightVariants(suggestionWords, mappedVariants, marker, textColor)
 }
 
 private fun mapSuggestionVariants(
@@ -230,7 +250,8 @@ private fun fixMultipleMarkers(mappedVariants: ArrayList<String>, marker: Char) 
 private fun highlightVariants(
     suggestionWords: List<String>,
     mappedVariants: Map<String, ArrayList<String>>,
-    marker: Char
+    marker: Char,
+    textColor: Color
 ): AnnotatedString {
     val transport = FontFamily(
         Font(uk.gov.govuk.design.R.font.transport_bold, FontWeight.Bold),
@@ -242,7 +263,7 @@ private fun highlightVariants(
         fontSize = 17.sp,
         letterSpacing = 0.sp,
         fontWeight = FontWeight.Bold,
-        color = GovUkTheme.colourScheme.textAndIcons.primary,
+        color = textColor,
     )
 
     val highlightStyle = SpanStyle(
@@ -250,7 +271,7 @@ private fun highlightVariants(
         fontSize = 17.sp,
         letterSpacing = 0.sp,
         fontWeight = FontWeight.Light,
-        color = GovUkTheme.colourScheme.textAndIcons.primary,
+        color = textColor,
     )
 
     return buildAnnotatedString {
@@ -276,9 +297,11 @@ private fun highlightVariants(
 @Composable
 private fun HighlightSingleSearchTerm1Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "pay employers PAYE",
-                searchTerm = "pay"
+                searchTerm = "pay",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -288,9 +311,11 @@ private fun HighlightSingleSearchTerm1Preview() {
 @Composable
 private fun HighlightSingleSearchTerm2Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "payroll",
-                searchTerm = "pay"
+                searchTerm = "pay",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -300,9 +325,11 @@ private fun HighlightSingleSearchTerm2Preview() {
 @Composable
 private fun HighlightSingleSearchTerm3Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "pay self assessment",
-                searchTerm = "pay"
+                searchTerm = "pay",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -312,9 +339,11 @@ private fun HighlightSingleSearchTerm3Preview() {
 @Composable
 private fun HighlightSingleSearchTerm4Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "check your pay",
-                searchTerm = "pay"
+                searchTerm = "pay",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -324,9 +353,11 @@ private fun HighlightSingleSearchTerm4Preview() {
 @Composable
 private fun HighlightSingleSearchTerm5Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "understanding your pay",
-                searchTerm = "pay"
+                searchTerm = "pay",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -336,9 +367,11 @@ private fun HighlightSingleSearchTerm5Preview() {
 @Composable
 private fun HighlightDoubleSearchTerm1Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "pay your corporation tax bill",
-                searchTerm = "pay tax"
+                searchTerm = "pay tax",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -348,9 +381,11 @@ private fun HighlightDoubleSearchTerm1Preview() {
 @Composable
 private fun HighlightDoubleSearchTerm2Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "pay capital gain tax uk property",
-                searchTerm = "pay tax"
+                searchTerm = "pay tax",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -360,9 +395,11 @@ private fun HighlightDoubleSearchTerm2Preview() {
 @Composable
 private fun HighlightDoubleSearchTerm3Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "pay corporation tax",
-                searchTerm = "pay tax"
+                searchTerm = "pay tax",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -372,9 +409,11 @@ private fun HighlightDoubleSearchTerm3Preview() {
 @Composable
 private fun HighlightDoubleSearchTerm4Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "pay your corporation tax",
-                searchTerm = "pay tax"
+                searchTerm = "pay tax",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -384,9 +423,11 @@ private fun HighlightDoubleSearchTerm4Preview() {
 @Composable
 private fun HighlightDoubleSearchTerm5Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "pay tax",
-                searchTerm = "pay tax"
+                searchTerm = "pay tax",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -396,9 +437,11 @@ private fun HighlightDoubleSearchTerm5Preview() {
 @Composable
 private fun HighlightMultipleSearchTerms1Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "mouse house housey mousey",
-                searchTerm = "hou ous"
+                searchTerm = "hou ous",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -408,9 +451,11 @@ private fun HighlightMultipleSearchTerms1Preview() {
 @Composable
 private fun HighlightMultipleSearchTerms2Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "Android Android android",
-                searchTerm = "and oi"
+                searchTerm = "and oi",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -420,9 +465,11 @@ private fun HighlightMultipleSearchTerms2Preview() {
 @Composable
 private fun HighlightMultipleSearchTerms3Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "Ho! Ho! Ho! said the mouse as it moved into a new house",
-                searchTerm = "ou Ho ho"
+                searchTerm = "ou Ho ho",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }
@@ -432,9 +479,11 @@ private fun HighlightMultipleSearchTerms3Preview() {
 @Composable
 private fun HighlightMultipleSearchTerms4Preview() {
     GovUkTheme {
-        Text(text = highlightSearchTerms(
+        Text(
+            text = highlightSearchTerms(
                 suggestion = "mouse house housey mousey mousehouse",
-                searchTerm = "hou ous"
+                searchTerm = "hou ous",
+                textColor = GovUkTheme.colourScheme.textAndIcons.primary
             )
         )
     }

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/EditTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/EditTopicsScreen.kt
@@ -59,14 +59,9 @@ private fun EditTopicsScreen(
     modifier: Modifier = Modifier
 ) {
     val title = stringResource(R.string.edit_title)
-    val focusRequester = remember { FocusRequester() }
 
     RunOnceLaunchedEffect {
         onPageView(title)
-    }
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
     }
 
     Column(modifier) {
@@ -75,15 +70,14 @@ private fun EditTopicsScreen(
             actionStyle = HeaderActionStyle.TextActionButton(
                 title = stringResource(R.string.done_button),
                 onClick = onDone
-            ),
-            modifier = Modifier.focusRequester(focusRequester)
+            )
         )
         LazyColumn(
             Modifier
                 .padding(horizontal = GovUkTheme.spacing.medium)
         ) {
             item {
-                Column{
+                Column {
                     MediumVerticalSpacer()
                     BodyRegularLabel(stringResource(R.string.edit_message))
                     MediumVerticalSpacer()

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/component/Card.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/component/Card.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +16,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,11 +41,12 @@ fun TopicSelectionCard(
     modifier: Modifier = Modifier
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
 
-    val backgroundColor = if (isSelected) {
-        GovUkTheme.colourScheme.surfaces.listSelected
-    } else {
-        GovUkTheme.colourScheme.surfaces.listUnselected
+    val (backgroundColor, textColour) = when {
+        isFocused -> GovUkTheme.colourScheme.surfaces.focused to GovUkTheme.colourScheme.textAndIcons.focused
+        isSelected -> GovUkTheme.colourScheme.surfaces.listSelected to GovUkTheme.colourScheme.textAndIcons.listSelected
+        else -> GovUkTheme.colourScheme.surfaces.listUnselected to GovUkTheme.colourScheme.textAndIcons.listUnselected
     }
 
     val selected = stringResource(R.string.selected_alt_text)
@@ -107,12 +110,6 @@ fun TopicSelectionCard(
             }
 
             MediumHorizontalSpacer()
-
-            val textColour = if (isSelected) {
-                GovUkTheme.colourScheme.textAndIcons.listSelected
-            } else {
-                GovUkTheme.colourScheme.textAndIcons.listUnselected
-            }
 
             BodyBoldLabel(
                 text = title,


### PR DESCRIPTION
# Title

Added focus indicator when navigating using keyboard tab/arrow keys to some UI elements where it was missing. 

## JIRA ticket(s)
  - [GOVUKAPP-3984](https://govukverify.atlassian.net/browse/GOVUKAPP-3984)

## Figma
  - [Figma board](https://www.figma.com/design/x5i4a5RT0xMhJAcjoIxefb/2025-06-GOV.UK-app-library-v2--UX-refresh?node-id=14123-5629&t=pkxbBXO7OBvdE7wB-1)

## Screenshots

[Screen_recording_20260909_104644.webm](https://github.com/user-attachments/assets/ed6a223d-a902-4fee-a88c-e112f23d6246)

[Screen_recording_20260909_112012.webm](https://github.com/user-attachments/assets/907daef1-0694-4e11-a11f-a2d960b2fa35)

[Screen_recording_20260909_123728.webm](https://github.com/user-attachments/assets/01394452-7f3a-4637-b622-1cb377f11422)

[Screen_recording_20260909_130337.webm](https://github.com/user-attachments/assets/68010216-8d17-4e5a-80c7-0f3e71059185)

[Screen_recording_20260909_165457.webm](https://github.com/user-attachments/assets/e36266b8-15aa-41a8-9b1f-9c010e9c742f)

