### PR TITLE
GOVUKAPP-3970 : Add 'app_theme' parameter to support light and dark mode surveys

### DIFF
--- a/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.govuk.analytics
 
 import android.content.Context
+import android.content.res.Configuration
 import androidx.core.net.toUri
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.qualtrics.digital.Qualtrics
@@ -146,6 +147,10 @@ class QualtricsAnalyticsClient @Inject constructor(
         firebaseIdentifiers.sessionId?.let {
             qualtrics.properties.setString(FIREBASE_SESSION_ID, it)
         }
+
+        val darkMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val theme = if (darkMode == Configuration.UI_MODE_NIGHT_YES) "dark" else "light"
+        qualtrics.properties.setString("app_theme", theme)
 
         analyticsParameterKeys.forEach { key ->
             qualtrics.properties.setString(key, parameters[key]?.toString() ?: "")

--- a/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClientTest.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.analytics
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.Configuration
 import android.net.Uri
 import androidx.core.net.toUri
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -211,6 +212,36 @@ class QualtricsAnalyticsClientTest {
 
         verify(exactly = 1) {
             firebaseIdentifiers.refresh()
+        }
+    }
+
+    @Test
+    fun `Given the the user has light mode set, when an event is logged, then ensure light is sent as the app_theme`() {
+        val configuration = Configuration().apply {
+            uiMode = Configuration.UI_MODE_NIGHT_NO
+        }
+        every { context.resources.configuration } returns configuration
+
+        qualtricsAnalyticsClient.logEvent("event_name", mapOf("key" to "value"))
+
+        verify(exactly = 1) {
+            qualtricsProperties.setString("app_theme", "light")
+            qualtrics.registerViewVisit("event_name")
+        }
+    }
+
+    @Test
+    fun `Given the the user has dark mode set, when an event is logged, then ensure dark is sent as the app_theme`() {
+        val configuration = Configuration().apply {
+            uiMode = Configuration.UI_MODE_NIGHT_YES
+        }
+        every { context.resources.configuration } returns configuration
+
+        qualtricsAnalyticsClient.logEvent("event_name", mapOf("key" to "value"))
+
+        verify(exactly = 1) {
+            qualtricsProperties.setString("app_theme", "dark")
+            qualtrics.registerViewVisit("event_name")
         }
     }
 


### PR DESCRIPTION
**Note**: Any survey - in Qualtrics - without `app_theme` specified as embedded data, will silently ignore it when sent from the app. 

## JIRA ticket(s)
  - [GOVUKAPP-3970](https://govukverify.atlassian.net/browse/GOVUKAPP-3970)

## Video

[Screen_recording_20260911_095054.webm](https://github.com/user-attachments/assets/6dafdefc-3659-43c9-a801-5f8127fdded5)

